### PR TITLE
Only use fast and most important linters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_script:
 - go build
 - go install
 - go vet $EXCLUDE_VENDOR
-- travis_wait 20 gometalinter ./... --vendor --deadline 20m
 - travis_wait 20 gometalinter ./... --vendor --fast --deadline 20m
 - travis_wait 20 gometalinter ./... --vendor --disable-all --enable=staticcheck --enable=gosimple  --deadline 20m
 script:


### PR DESCRIPTION
`gometalinter` was timing out under Travis.  Include fast linters and the ones we consider most important.