### PR TITLE
Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# https://hub.docker.com/_/golang/
+FROM golang:1.8-alpine
+
+WORKDIR /go/src/app
+
+COPY prometheus_nats_exporter.go .
+
+RUN apk add --no-cache git \
+  && go-wrapper download \
+  && go-wrapper download github.com/nats-io/go-nats \
+  && go-wrapper download github.com/nats-io/gnatsd \
+  && go-wrapper download github.com/mattn/goveralls \
+  && go-wrapper download github.com/wadey/gocovmerge \
+  && go-wrapper download github.com/alecthomas/gometalinter
+
+RUN go-wrapper install
+
+# Expose Prometheus port to listen on
+EXPOSE 7777
+
+ENTRYPOINT ["go-wrapper", "run"]


### PR DESCRIPTION
Docker Image that can be used as (right now for testing purpose) :
`docker run logimethods/prometheus-nats-exporter -varz "http://localhost:5555"`

That container has been tested thanks to https://github.com/Logimethods/smart-meter/commit/41cf729d292326d483757110bce4bf7f59be39af 

That Dockerfile should be eventually pushed to an official NATS repo in DockerHub.