### PR TITLE
Promote one-to-one usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License][License-Image]][License-Url] [![Build][Build-Status-Image]][Build-Status-Url] [![Coverage][Coverage-Image]][Coverage-Url]
 # The Prometheus NATS Exporter
-The Prometheus NATS Exporter consists of both a both a package and application that exports [NATS server](http://nats.io/documentation/server/gnatsd-intro/) metrics to [Prometheus](https://prometheus.io/) for monitoring.  The exporter aggregates metrics from the server monitoring endpoints you choose (varz, connz, subsz, routez) across any number of monitored NATS servers into a single Prometheus Exporter endpoint.
+The Prometheus NATS Exporter consists of both a both a package and application that exports [NATS server](http://nats.io/documentation/server/gnatsd-intro/) metrics to [Prometheus](https://prometheus.io/) for monitoring.  The exporter aggregates metrics from the server monitoring endpoints you choose (varz, connz, subsz, routez) from a NATS server into a single Prometheus exporter endpoint.
 
 # Build
 ``` bash
@@ -8,15 +8,15 @@ go build
 ```
 
 # Run
-Start the prometheus-nats-exporter executable, and poll the varz metrics endpoints of NATS servers 
-located at localhost:5555 and localhost:5656
+Start the prometheus-nats-exporter executable, and poll the `varz` metrics endpoints of the NATS server
+located on `localhost` configured with a monitor port of `5555`.
 ``` bash
-prometheus-nats-exporter -varz "http://localhost:5555" "http://localhost:5656"
+prometheus-nats-exporter -varz "http://localhost:5555"
 ```
 
 ## Usage
 ```bash
-prometheus-nats-exporter <flags> url <url url url>
+prometheus-nats-exporter <flags> url
 
 Flags must include at least one of: -varz, -connz, -routez, -subz
 
@@ -105,18 +105,17 @@ The NATS prometheus exporter also provides a simple and easy to use API that all
 ## API Usage
 In just a few lines of code, configure and launch an instance of the exporter.
 ```go 
-	// Get the default options, and set what you need to.  The listen address and Port
+	// Get the default options, and set what you need to.  The listen address and port
 	// is how prometheus can poll for collected data.
 	opts := exporter.GetDefaultExporterOptions()
 	opts.ListenAddress = "localhost"
 	opts.ListenPort = 8888
 	opts.GetVarz = true
+	opts.NATSServerURL = "http://localhost:8222"
+	opts.NATSServerTag = "myserver"
 
 	// create an exporter instance, ready to be launched.
 	exp := exporter.NewExporter(opts)
-
-	// Add a NATS server providing a tag and the monitoring url
-	exp.AddServer("myserver", "http://localhost:8222")
 
 	// start collecting data
 	exp.Start()

--- a/prometheus_nats_exporter.go
+++ b/prometheus_nats_exporter.go
@@ -88,10 +88,18 @@ func main() {
 
 	opts.RetryInterval = time.Duration(retryInterval) * time.Second
 
-	if len(flag.Args()) < 1 {
-		fmt.Printf("Usage:  %s <flags> url <url url url>\n\n", os.Args[0])
+	args := flag.Args()
+	if len(args) < 1 {
+		fmt.Printf("Usage:  %s <flags> url\n\n", os.Args[0])
 		flag.Usage()
 		return
+	} else if len(args) > 1 {
+		fmt.Println(
+			`WARNING:  While permitted by this exporter, monitoring more than one server 
+violates Prometheus guidelines and best practices.  Each Prometheus NATS 
+exporter should monitor exactly one NATS server, preferably sitting right 
+beside it on the same machine.  Aggregate multiple servers only when 
+necessary.`)
 	}
 
 	updateOptions(debugAndTrace, useSysLog, opts)
@@ -109,7 +117,7 @@ func main() {
 
 	// Start the exporter.
 	if err := exp.Start(); err != nil {
-		collector.Fatalf("Got an error starting the exporter: %v\n", err)
+		collector.Fatalf("error starting the exporter: %v\n", err)
 	}
 
 	// Setup the interrupt handler to gracefully exit.


### PR DESCRIPTION
Per Prometheus guidelines, there should be a relationship of one exporter instance per NATS server.  Tweak the API and usage to reflect this.
* New options support setting a NATS server and tag when creating an Exporter.
* Issue a warning if violating Prometheus best practices
* Modify usage and examples to reflect a one-to-one exporter/NATS server relationship.

Related to comments found in [this](https://github.com/prometheus/docs/pull/748) pull request.