### PR TITLE
Strip credentials from default id (url)

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -72,6 +72,7 @@ func NewExporter(opts *NATSExporterOptions) *NATSExporter {
 		o = GetDefaultExporterOptions()
 		o.GetVarz = true
 	}
+	collector.ConfigureLogger(&o.LoggerOptions)
 	ne := &NATSExporter{
 		opts: o,
 		http: nil,
@@ -128,7 +129,6 @@ func (ne *NATSExporter) AddServer(id, url string) error {
 // Caller must lock
 func (ne *NATSExporter) initializeCollectors() error {
 	opts := ne.opts
-	collector.ConfigureLogger(&opts.LoggerOptions)
 
 	if len(ne.servers) == 0 {
 		return fmt.Errorf("no servers configured to obtain metrics")


### PR DESCRIPTION
If not provided, the id/tag for the server defaults to the url and can leak credentials.  

This PR does a few things:

* Strips credentials from the supplied url when generating a default id
* Checks for invalid URLs earlier, rather than later
* Fixed a bug where the logger wasn't setup early enough

Resolves #22 