### PR TITLE
make the metrics export URL path configurable

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -309,6 +309,10 @@ func (ne *NATSExporter) startHTTP(listenAddress string, listenPort int) error {
 	hp = net.JoinHostPort(ne.opts.ListenAddress, strconv.Itoa(ne.opts.ListenPort))
 	path = ne.opts.ScrapePath
 
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
 	// If a certificate file has been specified, setup TLS with the
 	// key provided.
 	if ne.opts.CertFile != "" {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -270,6 +270,27 @@ func TestExporterScrapePathOption(t *testing.T) {
 	}
 }
 
+func TestExporterScrapePathOptionAddsSlash(t *testing.T) {
+	opts := getDefaultExporterTestOptions()
+	opts.ListenAddress = "localhost"
+	opts.ListenPort = 0
+	opts.ScrapePath = "elsewhere"
+	opts.GetVarz = true
+
+	s := pet.RunServer()
+	defer s.Shutdown()
+
+	exp := NewExporter(opts)
+	if err := exp.Start(); err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer exp.Stop()
+
+	if err := checkExporterFull(t, "", "", exp.http.Addr().String(), "/elsewhere", false, http.StatusOK); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
 func TestExporterWait(t *testing.T) {
 	s := pet.RunServer()
 	defer s.Shutdown()

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -70,23 +70,23 @@ func httpGet(url string) (*http.Response, error) {
 	return httpClient.Get(url)
 }
 
-func buildExporterURL(user, pass, addr string, secure bool) string {
+func buildExporterURL(user, pass, addr string, path string, secure bool) string {
 	proto := "http"
 	if secure {
 		proto = "https"
 	}
 
 	if user != "" {
-		return fmt.Sprintf("%s://%s:%s@%s/metrics", proto, user, pass, addr)
+		return fmt.Sprintf("%s://%s:%s@%s%s", proto, user, pass, addr, path)
 	}
 
-	return fmt.Sprintf("%s://%s/metrics", proto, addr)
+	return fmt.Sprintf("%s://%s%s", proto, addr, path)
 }
 
-func checkExporterFull(t *testing.T, user, pass, addr string, secure bool, expectedRc int) error {
+func checkExporterFull(t *testing.T, user, pass, addr string, path string, secure bool, expectedRc int) error {
 	var resp *http.Response
 	var err error
-	url := buildExporterURL(user, pass, addr, secure)
+	url := buildExporterURL(user, pass, addr, path, secure)
 
 	if secure {
 		resp, err = httpGetSecure(url)
@@ -123,7 +123,7 @@ func checkExporterFull(t *testing.T, user, pass, addr string, secure bool, expec
 }
 
 func checkExporter(t *testing.T, addr string, secure bool) error {
-	return checkExporterFull(t, "", "", addr, secure, http.StatusOK)
+	return checkExporterFull(t, "", "", addr, "/metrics", secure, http.StatusOK)
 }
 
 func TestExporter(t *testing.T) {
@@ -242,6 +242,30 @@ func TestExporterDefaultOptions(t *testing.T) {
 	defer exp.Stop()
 
 	if err := checkExporter(t, exp.http.Addr().String(), false); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestExporterScrapePathOption(t *testing.T) {
+	opts := getDefaultExporterTestOptions()
+	opts.ListenAddress = "localhost"
+	opts.ListenPort = 0
+	opts.ScrapePath = "/some/other/path/to/metrics"
+	opts.GetVarz = true
+	opts.GetConnz = true
+	opts.GetSubz = true
+	opts.GetRoutez = true
+
+	s := pet.RunServer()
+	defer s.Shutdown()
+
+	exp := NewExporter(opts)
+	if err := exp.Start(); err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer exp.Stop()
+
+	if err := checkExporterFull(t, "", "", exp.http.Addr().String(), "/some/other/path/to/metrics", false, http.StatusOK); err != nil {
 		t.Fatalf("%v", err)
 	}
 }
@@ -477,7 +501,7 @@ func testBasicAuth(t *testing.T, opts *NATSExporterOptions, testuser, testpass s
 	}
 	defer exp.Stop()
 
-	return checkExporterFull(t, testuser, testpass, exp.http.Addr().String(), false, expectedRc)
+	return checkExporterFull(t, testuser, testpass, exp.http.Addr().String(), "/metrics", false, expectedRc)
 }
 
 func TestExporterBasicAuth(t *testing.T) {

--- a/prometheus_nats_exporter.go
+++ b/prometheus_nats_exporter.go
@@ -91,6 +91,7 @@ func main() {
 	flag.IntVar(&opts.ListenPort, "p", exporter.DefaultListenPort, "Port to listen on.")
 	flag.StringVar(&opts.ListenAddress, "addr", exporter.DefaultListenAddress, "Network host to listen on.")
 	flag.StringVar(&opts.ListenAddress, "a", exporter.DefaultListenAddress, "Network host to listen on.")
+	flag.StringVar(&opts.ScrapePath, "path", exporter.DefaultScrapePath, "URL path from which to serve scrapes.")
 	flag.IntVar(&retryInterval, "ri", exporter.DefaultRetryIntervalSecs, "Interval in seconds to retry NATS Server monitor URL.")
 	flag.StringVar(&opts.LogFile, "l", "", "Log file name.")
 	flag.StringVar(&opts.LogFile, "log", "", "Log file name.")


### PR DESCRIPTION
This makes the exporter path configurable instead of hard coded to "/metrics".

This will make fewer assumptions on environments the exporter is used in, as well as make this NATS  exporter behave in line with many other prometheus exporters.

I'm pretty sure this is my first real pull request on GitHub, so please enlighten me if I'm doing something unorthodox.