### PR TITLE
Add Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ _testmain.go
 *.test
 *.prof
 travis_wait*.log
+
+# Exclude the go build binary
+prometheus-nats-exporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.11
+
+COPY . /go/src/github.com/nats-io/prometheus-nats-exporter
+WORKDIR /go/src/github.com/nats-io/prometheus-nats-exporter
+
+RUN go build
+
+EXPOSE 7777
+ENTRYPOINT ["./prometheus-nats-exporter"]
+CMD ["--help"]


### PR DESCRIPTION
It would be nice to have this pushed to public docker hub, so that consumers can pull via `docker pull nats-io/prometheus-nats-exporter`. It looks like currently the operator uses [this image](https://github.com/nats-io/nats-operator/pull/84/files#diff-3e1f0c8b72ef4435e5f056caf447e077R146), which is a little confusing and was tough-ish to find.