### PR TITLE
Add missing maintainer to Debian builds (#57)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,6 +49,7 @@ nfpm:
   bindir: /usr/local/bin
   description: A Prometheus exporter for NATS
   vendor: nats.io
+  maintainer: Colin Sullivan <colin@nats.io>
   homepage: https://nats.io
   license: Apache 2.0
 


### PR DESCRIPTION
To fix warnings when working with the Debian package a maintainer has been added to the goreleaser configuration (nfpm section). This should fixes issue #57