### PR TITLE
Add inbox label for when multiple subscriptions on single connection

### DIFF
--- a/collector/streaming.go
+++ b/collector/streaming.go
@@ -155,19 +155,19 @@ func newChannelsCollector(servers []*CollectedServer) prometheus.Collector {
 		subsLastSent: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "chan", "subs_last_sent"),
 			"Last message sent",
-			[]string{"server", "channel", "client_id"},
+			[]string{"server", "channel", "client_id", "inbox"},
 			nil,
 		),
 		subsPendingCount: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "chan", "subs_pending_count"),
 			"Pending message count",
-			[]string{"server", "channel", "client_id"},
+			[]string{"server", "channel", "client_id", "inbox"},
 			nil,
 		),
 		subsMaxInFlight: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "chan", "subs_max_inflight"),
 			"Max in flight message count",
-			[]string{"server", "channel", "client_id"},
+			[]string{"server", "channel", "client_id", "inbox"},
 			nil,
 		),
 	}
@@ -208,9 +208,9 @@ func (nc *channelsCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(nc.chanLastSeq, prometheus.GaugeValue, float64(channel.LastSeq), server.ID, channel.Name)
 
 			for _, sub := range channel.Subscriptions {
-				ch <- prometheus.MustNewConstMetric(nc.subsLastSent, prometheus.GaugeValue, float64(sub.LastSent), server.ID, channel.Name, sub.ClientID)
-				ch <- prometheus.MustNewConstMetric(nc.subsPendingCount, prometheus.GaugeValue, float64(sub.PendingCount), server.ID, channel.Name, sub.ClientID)
-				ch <- prometheus.MustNewConstMetric(nc.subsMaxInFlight, prometheus.GaugeValue, float64(sub.MaxInflight), server.ID, channel.Name, sub.ClientID)
+				ch <- prometheus.MustNewConstMetric(nc.subsLastSent, prometheus.GaugeValue, float64(sub.LastSent), server.ID, channel.Name, sub.ClientID, sub.Inbox)
+				ch <- prometheus.MustNewConstMetric(nc.subsPendingCount, prometheus.GaugeValue, float64(sub.PendingCount), server.ID, channel.Name, sub.ClientID, sub.Inbox)
+				ch <- prometheus.MustNewConstMetric(nc.subsMaxInFlight, prometheus.GaugeValue, float64(sub.MaxInflight), server.ID, channel.Name, sub.ClientID, sub.Inbox)
 			}
 		}
 	}


### PR DESCRIPTION
Adding a label for the `inbox`, because we have a use case to have many subscriptions to the same channel on the same connection.

Upon testing the streaming metrics, I was met with:

> collected metric nss_chan_subs_last_sent label:<name:"channel" value:"<subject>" > label:<name:"client_id" value:"<pod-name>" > label:<name:"server" value:"http://localhost:8222" > gauge:<value:2165 >  was collected before with the same name and label values

In order to resolve, I added the `inbox` field as there is no other subscription identifier exposed in the endpoints.