### PR TITLE
Server info metric (nss_server_info)

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -208,7 +208,7 @@ func NewCollector(endpoint string, servers []*CollectedServer) prometheus.Collec
 	if isStreamingEndpoint(endpoint) {
 		return newStreamingCollector(endpoint, servers)
 	}
-	
+
 	// TODO:  Potentially add TLS config in the transport.
 	tr := &http.Transport{}
 	hc := &http.Client{Transport: tr}


### PR DESCRIPTION
Fixes #69 

# Description

Exporting some server info as labels on the `nss_server_info` metric.

# Proof This Works

If manually hitting the monitoring endpoint for the `nats-streaming-server` yields the following server information:

![Screen Shot 2019-04-24 at 4 31 54 PM](https://user-images.githubusercontent.com/16242580/56691683-8ef0d000-66ae-11e9-9d28-b8ef52d5839a.png)

Then the exporter will report it like so:

![Screen Shot 2019-04-24 at 4 33 12 PM](https://user-images.githubusercontent.com/16242580/56691773-c1023200-66ae-11e9-8b1a-a24349933a6a.png)
