### PR TITLE
feat: connz: monitor pending bytes

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -208,6 +208,9 @@ func NewCollector(endpoint string, servers []*CollectedServer) prometheus.Collec
 	if isStreamingEndpoint(endpoint) {
 		return newStreamingCollector(endpoint, servers)
 	}
+	if isConnzEndpoint(endpoint) {
+		return newConnzCollector(servers)
+	}
 
 	// TODO:  Potentially add TLS config in the transport.
 	tr := &http.Transport{}

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/go-nats-streaming"
+	stan "github.com/nats-io/go-nats-streaming"
 	pet "github.com/nats-io/prometheus-nats-exporter/test"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -164,6 +164,7 @@ func TestConnz(t *testing.T) {
 
 	cases := map[string]float64{
 		"gnatsd_connz_total_connections": 0,
+		"gnatsd_connz_pending_bytes":     0,
 		"gnatsd_varz_connections":        0,
 	}
 
@@ -173,6 +174,7 @@ func TestConnz(t *testing.T) {
 
 	cases = map[string]float64{
 		"gnatsd_connz_total_connections": 1,
+		"gnatsd_connz_pending_bytes":     0,
 		"gnatsd_varz_connections":        1,
 	}
 	nc := pet.CreateClientConnSubscribeAndPublish(t)

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -446,7 +446,7 @@ func TestStreamingSubscriptionsMetricLabels(t *testing.T) {
 		}
 
 		foundQueuedDurableLabels := false
-		expectedLabelNames := []string{"server", "channel", "client_id", "inbox",
+		expectedLabelNames := []string{"server_id", "channel", "client_id", "inbox",
 			"queue_name", "is_durable", "is_offline"}
 		for subscriptionIndex := range subscriptions {
 			expectedLabelsNotFound := make([]string, 0)

--- a/collector/connz.go
+++ b/collector/connz.go
@@ -1,0 +1,108 @@
+package collector
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func isConnzEndpoint(endpoint string) bool {
+	return endpoint == "connz"
+}
+
+type connzCollector struct {
+	sync.Mutex
+
+	httpClient *http.Client
+	servers    []*CollectedServer
+
+	numConnections *prometheus.Desc
+	total          *prometheus.Desc
+	offset         *prometheus.Desc
+	limit          *prometheus.Desc
+	pendingBytes   *prometheus.Desc
+}
+
+func newConnzCollector(servers []*CollectedServer) prometheus.Collector {
+	nc := &connzCollector{
+		httpClient: http.DefaultClient,
+		numConnections: prometheus.NewDesc(
+			prometheus.BuildFQName("gnatsd", "connz", "num_connections"),
+			"num_connections",
+			[]string{"server_id"},
+			nil,
+		),
+		offset: prometheus.NewDesc(
+			prometheus.BuildFQName("gnatsd", "connz", "offset"),
+			"offset",
+			[]string{"server_id"},
+			nil,
+		),
+		total: prometheus.NewDesc(
+			prometheus.BuildFQName("gnatsd", "connz", "total"),
+			"total",
+			[]string{"server_id"},
+			nil,
+		),
+		limit: prometheus.NewDesc(
+			prometheus.BuildFQName("gnatsd", "connz", "limit"),
+			"limit",
+			[]string{"server_id"},
+			nil,
+		),
+		pendingBytes: prometheus.NewDesc(
+			prometheus.BuildFQName("gnatsd", "connz", "pending_bytes"),
+			"pending_bytes",
+			[]string{"server_id"},
+			nil,
+		),
+	}
+
+	nc.servers = make([]*CollectedServer, len(servers))
+	for i, s := range servers {
+		nc.servers[i] = &CollectedServer{
+			ID:  s.ID,
+			URL: s.URL + "/connz",
+		}
+	}
+
+	return nc
+}
+
+func (nc *connzCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- nc.limit
+}
+
+// Collect gathers the streaming server serverz metrics.
+func (nc *connzCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, server := range nc.servers {
+		var resp Connz
+		if err := getMetricURL(nc.httpClient, server.URL, &resp); err != nil {
+			Debugf("ignoring server %s: %v", server.ID, err)
+			continue
+		}
+
+		var pendingBytes = 0
+		for _, conn := range resp.Connections {
+			pendingBytes += conn.PendingBytes
+		}
+
+		ch <- prometheus.MustNewConstMetric(nc.numConnections, prometheus.GaugeValue, float64(resp.NumConnections), server.ID)
+		ch <- prometheus.MustNewConstMetric(nc.total, prometheus.GaugeValue, float64(resp.Total), server.ID)
+		ch <- prometheus.MustNewConstMetric(nc.offset, prometheus.GaugeValue, float64(resp.Offset), server.ID)
+		ch <- prometheus.MustNewConstMetric(nc.limit, prometheus.GaugeValue, float64(resp.Limit), server.ID)
+		ch <- prometheus.MustNewConstMetric(nc.pendingBytes, prometheus.GaugeValue, float64(pendingBytes), server.ID)
+	}
+}
+
+// Connz output
+type Connz struct {
+	NumConnections int `json:"num_connections"`
+	Total          int `json:"total"`
+	Offset         int `json:"offset"`
+	Limit          int `json:"limit"`
+	Connections    []struct {
+		PendingBytes int `json:"pending_bytes"`
+	} `json:"connections"`
+}

--- a/collector/streaming.go
+++ b/collector/streaming.go
@@ -149,25 +149,25 @@ type channelsCollector struct {
 }
 
 func newChannelsCollector(servers []*CollectedServer) prometheus.Collector {
-	subsVariableLabels := []string{"server", "channel", "client_id", "inbox", "queue_name", "is_durable", "is_offline"}
+	subsVariableLabels := []string{"server_id", "channel", "client_id", "inbox", "queue_name", "is_durable", "is_offline"}
 	nc := &channelsCollector{
 		httpClient: http.DefaultClient,
 		chanBytesTotal: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "chan", "bytes_total"),
 			"Total of bytes",
-			[]string{"server", "channel"},
+			[]string{"server_id", "channel"},
 			nil,
 		),
 		chanMsgsTotal: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "chan", "msgs_total"),
 			"Total of messages",
-			[]string{"server", "channel"},
+			[]string{"server_id", "channel"},
 			nil,
 		),
 		chanLastSeq: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "chan", "last_seq"),
 			"Last seq",
-			[]string{"server", "channel"},
+			[]string{"server_id", "channel"},
 			nil,
 		),
 		subsLastSent: prometheus.NewDesc(

--- a/collector/streaming.go
+++ b/collector/streaming.go
@@ -45,37 +45,37 @@ func newServerzCollector(servers []*CollectedServer) prometheus.Collector {
 		bytesTotal: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "server", "bytes_total"),
 			"Total of bytes",
-			[]string{"server"},
+			[]string{"server_id"},
 			nil,
 		),
 		msgsTotal: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "server", "msgs_total"),
 			"Total of messages",
-			[]string{"server"},
+			[]string{"server_id"},
 			nil,
 		),
 		channels: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "server", "channels"),
 			"Total channels",
-			[]string{"server"},
+			[]string{"server_id"},
 			nil,
 		),
 		subs: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "server", "subscriptions"),
 			"Total subscriptions",
-			[]string{"server"},
+			[]string{"server_id"},
 			nil,
 		),
 		clients: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "server", "clients"),
 			"Total clients",
-			[]string{"server"},
+			[]string{"server_id"},
 			nil,
 		),
 		info: prometheus.NewDesc(
 			prometheus.BuildFQName("nss", "server", "info"),
 			"Info",
-			[]string{"server", "cluster_id", "server_id", "version", "go_version", "state", "role", "start_time"},
+			[]string{"server_id", "cluster_id", "version", "go_version", "state", "role", "start_time"},
 			nil,
 		),
 	}
@@ -130,8 +130,7 @@ func (nc *serverzCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(nc.channels, prometheus.CounterValue, float64(resp.Channels), server.ID)
 		ch <- prometheus.MustNewConstMetric(nc.subs, prometheus.CounterValue, float64(resp.Subscriptions), server.ID)
 		ch <- prometheus.MustNewConstMetric(nc.clients, prometheus.CounterValue, float64(resp.Clients), server.ID)
-		ch <- prometheus.MustNewConstMetric(nc.info, prometheus.GaugeValue, 1, server.ID, resp.ClusterID, resp.ServerID,
-			resp.Version, resp.GoVersion, resp.State, resp.Role, resp.StartTime)
+		ch <- prometheus.MustNewConstMetric(nc.info, prometheus.GaugeValue, 1, server.ID, resp.ClusterID, resp.Version, resp.GoVersion, resp.State, resp.Role, resp.StartTime)
 	}
 }
 
@@ -240,7 +239,6 @@ func (nc *channelsCollector) Collect(ch chan<- prometheus.Metric) {
 // Channelsz lists the name of all NATS Streaming Channelsz
 type Channelsz struct {
 	ClusterID string      `json:"cluster_id"`
-	ServerID  string      `json:"server_id"`
 	Now       time.Time   `json:"now"`
 	Offset    int         `json:"offset"`
 	Limit     int         `json:"limit"`


### PR DESCRIPTION
The idea is to be able to alert if `pending_bytes` is close to `max_pending`.

I also fixed the streaming metrics so they have the same `server_id` label as all other metrics (instead of `server`).

I wanted to avoid too much cardinality, that's why I just reported one metric with the sum of all pending bytes. If you think its best to have them as separated metrics I can definitely change that.