### PR TITLE
fix: remove rpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ _testmain.go
 *.test
 *.prof
 travis_wait*.log
+
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 language: go
 go:
 - 1.11.x
-- 1.12.x  
+- 1.12.x
 
-addons:
-  apt:
-    packages:
-    # needed for the nfpm pipe:
-    - rpm
 install:
 - go get github.com/nats-io/go-nats
 - go get github.com/nats-io/gnatsd


### PR DESCRIPTION
Only the `deb` format is being used, so `rpm` is not a needed dependency.

Also added `dist` to gitignore so we can run `goreleaser --snapshot` and etc locally without worrying about it :) 