### PR TITLE
Add getting server id from /varz for the server

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -129,6 +129,17 @@ func getLabelValues(url string, endpoint string, metricNames []string) (map[stri
 	}
 }
 
+func TestServerIDFromVarz(t *testing.T) {
+	s := pet.RunServer()
+	defer s.Shutdown()
+
+	url := fmt.Sprintf("http://localhost:%d/", pet.MonitorPort)
+	result := GetServerIDFromVarz(url, 2*time.Second)
+	if len(result) < 1 || result[0] != 'N' {
+		t.Fatalf("Unexpected server id: %v", result)
+	}
+}
+
 func TestVarz(t *testing.T) {
 	s := pet.RunServer()
 	defer s.Shutdown()

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -53,6 +53,7 @@ type NATSExporterOptions struct {
 	HTTPUser             string // User in metrics scrape by prometheus.
 	HTTPPassword         string
 	Prefix               string
+	UseOldServerID       bool
 }
 
 //NATSExporter collects NATS metrics

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -53,7 +53,7 @@ type NATSExporterOptions struct {
 	HTTPUser             string // User in metrics scrape by prometheus.
 	HTTPPassword         string
 	Prefix               string
-	UseOldServerID       bool
+	UseInternalServerID  bool
 }
 
 //NATSExporter collects NATS metrics

--- a/prometheus_nats_exporter.go
+++ b/prometheus_nats_exporter.go
@@ -118,7 +118,7 @@ func main() {
 	flag.StringVar(&opts.HTTPUser, "http_user", "", "Enable basic auth and set user name for HTTP scrapes.")
 	flag.StringVar(&opts.HTTPPassword, "http_pass", "", "Set the password for HTTP scrapes. NATS bcrypt supported.")
 	flag.StringVar(&opts.Prefix, "prefix", "", "Set the prefix for all the metrics.")
-	flag.BoolVar(&opts.UseOldServerID, "use_old_server_id", false, "Disables using ServerID from /varz")
+	flag.BoolVar(&opts.UseInternalServerID, "use_internal_server_id", false, "Enables using ServerID from /varz")
 	flag.Parse()
 
 	opts.RetryInterval = time.Duration(retryInterval) * time.Second
@@ -147,7 +147,7 @@ necessary.`)
 	// Create an instance of the NATS exporter.
 	exp := exporter.NewExporter(opts)
 
-	if len(args) == 1 && !opts.UseOldServerID {
+	if len(args) == 1 && opts.UseInternalServerID {
 		// Pick the server id from the /varz endpoint info.
 		url := flag.Args()[0]
 		id := collector.GetServerIDFromVarz(url, opts.RetryInterval)


### PR DESCRIPTION
This makes now the default to use the generated server id from the server instead of the endpoint that is specified via the command line.

```
# HELP nats_connz_limit limit
# TYPE nats_connz_limit gauge
nats_connz_limit{server_id="NB2MKHILGR5SVPLCBBQCTLK2D7PBOE6XDKP3EHXHHZ7M33JBEC4WHFCN"} 1024
# HELP nats_connz_num_connections num_connections
# TYPE nats_connz_num_connections gauge
nats_connz_num_connections{server_id="NB2MKHILGR5SVPLCBBQCTLK2D7PBOE6XDKP3EHXHHZ7M33JBEC4WHFCN"} 0
```

In order to revert to previous behavior can specify the following:

```
  -use_old_server_id
    	Disables using ServerID from /varz
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>