### PR TITLE
Fix CI modifying files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,22 @@ go:
 - 1.12.x
 
 install:
-- go get github.com/nats-io/go-nats
-- go get github.com/nats-io/nats-server
-- go get github.com/nats-io/nats-replicator
-- go get github.com/mattn/goveralls
-- go get github.com/wadey/gocovmerge
-- go get github.com/alecthomas/gometalinter
+- go get -v github.com/nats-io/go-nats
+- go get -v github.com/nats-io/nats-server
+- go get -v github.com/nats-io/nats-replicator
+- go get -v github.com/mattn/goveralls
+- go get -v github.com/wadey/gocovmerge
+- go get -v github.com/alecthomas/gometalinter
 - gometalinter --install
 before_script:
 - EXCLUDE_VENDOR=$(go list ./... | grep -v "/vendor/")
-- go fmt ./...
-- go build
-- go install
+- test -z "$(gofmt -l . | grep -v "vendor/")"
+- go build -v
+- go install -v
 - go vet $EXCLUDE_VENDOR
 - travis_wait 20 gometalinter ./... --vendor --disable=gocyclo --fast --deadline 20m
 script:
-- go test -i -race $EXCLUDE_VENDOR -p 1
+- go test -v -i -race $EXCLUDE_VENDOR -p 1
 - go test -v -race $EXCLUDE_VENDOR -p 1
 after_success:
 - if [[ "$TRAVIS_GO_VERSION" == 1.12.* ]]; then ./scripts/cov.sh TRAVIS; fi

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -599,24 +599,24 @@ func TestReplicatorMetrics(t *testing.T) {
 	// streaming servers in the same process.
 	r, err := pet.RunTestReplicator(9922, pet.ClientPort, pet.ClientPort+1)
 	if err != nil {
-	   t.Fatalf("couldn't start replicator, %s", err)
+		t.Fatalf("couldn't start replicator, %s", err)
 	}
 	defer r.Stop()
 
 	cases := map[string]float64{
-		"replicator_connector_bytes_in": 0,
-		"replicator_connector_bytes_out": 0,
-		"replicator_connector_connected": 1,
-		"replicator_connector_connects": 1,
-		"replicator_connector_disconnects": 0,
-		"replicator_connector_messages_in": 0,
-		"replicator_connector_messages_out": 0,
+		"replicator_connector_bytes_in":       0,
+		"replicator_connector_bytes_out":      0,
+		"replicator_connector_connected":      1,
+		"replicator_connector_connects":       1,
+		"replicator_connector_disconnects":    0,
+		"replicator_connector_messages_in":    0,
+		"replicator_connector_messages_out":   0,
 		"replicator_connector_moving_average": 0,
-		"replicator_connector_quintile_50": -1,
-		"replicator_connector_quintile_75": -1,
-		"replicator_connector_quintile_90": -1,
-		"replicator_connector_quintile_95": -1,
-		"replicator_connector_request_count": 0,
+		"replicator_connector_quintile_50":    -1,
+		"replicator_connector_quintile_75":    -1,
+		"replicator_connector_quintile_90":    -1,
+		"replicator_connector_quintile_95":    -1,
+		"replicator_connector_request_count":  0,
 	}
 
 	url := "http://127.0.0.1:9922"

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -609,7 +609,7 @@ func TestExporterReplicator(t *testing.T) {
 	// streaming servers in the same process.
 	r, err := pet.RunTestReplicator(9999, pet.ClientPort, pet.ClientPort+1)
 	if err != nil {
-	   t.Fatalf("couldn't start replicator, %s", err)
+		t.Fatalf("couldn't start replicator, %s", err)
 	}
 	defer r.Stop()
 


### PR DESCRIPTION
Currently, the `go fmt` command in the Travis CI file is modifying files that
aren't properly formatted. This causes the release to fail.

This change uses `test -z` to test if any files need formatting. In addition,
I'm also adding a `-v` flag to more go commands so we can more easily debug Go
issues in the future.