### PR TITLE
Remove bins from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 travis_wait*.log
 
 dist/
+prometheus-nats-exporter


### PR DESCRIPTION
Currently, the prometheus-nats-exporter binary isn't being ignored in git. Also,
there is a macOS binary in the vendor folder.

This change ignores prometheus-nats-exporter and removes the macOS binary.