### PR TITLE
Include msgsin msgsout fields

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -382,8 +382,6 @@ func TestStreamingMetrics(t *testing.T) {
 	cases := map[string]float64{
 		"test_chan_bytes_total":        240,
 		"test_chan_msgs_total":         10,
-		"test_chan_msgs_in":            10,
-		"test_chan_msgs_out":           10,
 		"test_chan_last_seq":           10,
 		"test_chan_subs_last_sent":     10,
 		"test_chan_subs_pending_count": 0,
@@ -394,6 +392,8 @@ func TestStreamingMetrics(t *testing.T) {
 
 	cases = map[string]float64{
 		"test_server_bytes_total":   0,
+		"test_server_bytes_in":      0,
+		"test_server_bytes_out":     0,
 		"test_server_msgs_total":    0,
 		"test_chan_msgs_in":         0,
 		"test_chan_msgs_out":        0,
@@ -436,8 +436,6 @@ func TestStreamingMetricsCustomPrefix(t *testing.T) {
 	cases := map[string]float64{
 		"nss_chan_bytes_total":        240,
 		"nss_chan_msgs_total":         10,
-		"nss_chan_msgs_in":            10,
-		"nss_chan_msgs_out":           10,
 		"nss_chan_last_seq":           10,
 		"nss_chan_subs_last_sent":     10,
 		"nss_chan_subs_pending_count": 0,
@@ -448,6 +446,8 @@ func TestStreamingMetricsCustomPrefix(t *testing.T) {
 
 	cases = map[string]float64{
 		"nss_server_bytes_total":   0,
+		"nss_server_bytes_in":      0,
+		"nss_server_bytes_out":     0,
 		"nss_server_msgs_total":    0,
 		"nss_chan_msgs_in":         0,
 		"nss_chan_msgs_out":        0,

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -382,6 +382,8 @@ func TestStreamingMetrics(t *testing.T) {
 	cases := map[string]float64{
 		"test_chan_bytes_total":        240,
 		"test_chan_msgs_total":         10,
+		"test_chan_msgs_in":            10,
+		"test_chan_msgs_out":           10,
 		"test_chan_last_seq":           10,
 		"test_chan_subs_last_sent":     10,
 		"test_chan_subs_pending_count": 0,
@@ -393,6 +395,8 @@ func TestStreamingMetrics(t *testing.T) {
 	cases = map[string]float64{
 		"test_server_bytes_total":   0,
 		"test_server_msgs_total":    0,
+		"test_chan_msgs_in":         0,
+		"test_chan_msgs_out":        0,
 		"test_server_channels":      0,
 		"test_server_subscriptions": 0,
 		"test_server_clients":       0,
@@ -432,6 +436,8 @@ func TestStreamingMetricsCustomPrefix(t *testing.T) {
 	cases := map[string]float64{
 		"nss_chan_bytes_total":        240,
 		"nss_chan_msgs_total":         10,
+		"nss_chan_msgs_in":            10,
+		"nss_chan_msgs_out":           10,
 		"nss_chan_last_seq":           10,
 		"nss_chan_subs_last_sent":     10,
 		"nss_chan_subs_pending_count": 0,
@@ -443,6 +449,8 @@ func TestStreamingMetricsCustomPrefix(t *testing.T) {
 	cases = map[string]float64{
 		"nss_server_bytes_total":   0,
 		"nss_server_msgs_total":    0,
+		"nss_chan_msgs_in":         0,
+		"nss_chan_msgs_out":        0,
 		"nss_server_channels":      0,
 		"nss_server_subscriptions": 0,
 		"nss_server_clients":       0,

--- a/collector/streaming.go
+++ b/collector/streaming.go
@@ -241,7 +241,7 @@ func newChannelsCollector(system string, servers []*CollectedServer) prometheus.
 	for i, s := range servers {
 		nc.servers[i] = &CollectedServer{
 			ID:  s.ID,
-			URL: s.URL + "/streaming/channelsz?subs=1",
+			URL: s.URL + "/streaming/channelsz?limit=30000&subs=1",
 		}
 	}
 

--- a/docker/linux/amd64/Dockerfile
+++ b/docker/linux/amd64/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.12
 
 # download the source
 WORKDIR /go/src/github.com/nats-io/prometheus-nats-exporter
-RUN git clone --branch v0.6.0 https://github.com/nats-io/prometheus-nats-exporter.git .
+RUN git clone https://github.com/renanberto/prometheus-nats-exporter.git .
 
 # build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w"

--- a/docker/linux/amd64/Dockerfile
+++ b/docker/linux/amd64/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.12
 
 # download the source
 WORKDIR /go/src/github.com/nats-io/prometheus-nats-exporter
-RUN git clone https://github.com/renanberto/prometheus-nats-exporter.git .
+RUN git clone --branch v0.6.0 https://github.com/nats-io/prometheus-nats-exporter.git .
 
 # build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w"


### PR DESCRIPTION
Hi guys.

This change is intended to include the new streaming-server API metrics `msgs_in` and` msgs_out`.
Thanks!

**[Warning]** this metric is only collected after this nats-streaming-server commit : https://github.com/nats-io/nats-streaming-server/commit/b95714efeef2e1bcc46d11da6f41bc88da1e1f04