### PR TITLE
Add server role to channel metrics to check cardinality

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -559,7 +559,7 @@ func TestStreamingSubscriptionsMetricLabels(t *testing.T) {
 		}
 
 		foundQueuedDurableLabels, foundDurableLabels := false, false
-		expectedLabelNames := []string{"server_id", "channel", "client_id", "inbox",
+		expectedLabelNames := []string{"server_id", "server_role", "channel", "client_id", "inbox",
 			"queue_name", "is_durable", "is_offline", "durable_name"}
 		for subscriptionIndex := range subscriptions {
 			expectedLabelsNotFound := make([]string, 0)

--- a/collector/streaming.go
+++ b/collector/streaming.go
@@ -24,6 +24,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const ChannelszSuffix = "/streaming/channelsz?subs=1"
+const ServerzSuffix = "/streaming/serverz"
+
 // newStreamingCollector collects channelsz and serversz metrics of
 // streaming servers.
 func newStreamingCollector(system, endpoint string, servers []*CollectedServer) prometheus.Collector {
@@ -136,7 +139,7 @@ func newServerzCollector(system string, servers []*CollectedServer) prometheus.C
 	for i, s := range servers {
 		nc.servers[i] = &CollectedServer{
 			ID:  s.ID,
-			URL: s.URL + "/streaming/serverz",
+			URL: s.URL + ServerzSuffix,
 		}
 	}
 
@@ -228,7 +231,7 @@ type channelsCollector struct {
 
 func newChannelsCollector(system string, servers []*CollectedServer) prometheus.Collector {
 	subsVariableLabels := []string{
-		"server_id", "channel", "client_id", "inbox", "queue_name",
+		"server_id", "server_role", "channel", "client_id", "inbox", "queue_name",
 		"is_durable", "is_offline", "durable_name",
 	}
 	nc := &channelsCollector{
@@ -237,19 +240,19 @@ func newChannelsCollector(system string, servers []*CollectedServer) prometheus.
 		chanBytesTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(system, "chan", "bytes_total"),
 			"Total of bytes",
-			[]string{"server_id", "channel"},
+			[]string{"server_id", "server_role", "channel"},
 			nil,
 		),
 		chanMsgsTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(system, "chan", "msgs_total"),
 			"Total of messages",
-			[]string{"server_id", "channel"},
+			[]string{"server_id", "server_role", "channel"},
 			nil,
 		),
 		chanLastSeq: prometheus.NewDesc(
 			prometheus.BuildFQName(system, "chan", "last_seq"),
 			"Last seq",
-			[]string{"server_id", "channel"},
+			[]string{"server_id", "server_role", "channel"},
 			nil,
 		),
 		subsLastSent: prometheus.NewDesc(
@@ -278,7 +281,7 @@ func newChannelsCollector(system string, servers []*CollectedServer) prometheus.
 	for i, s := range servers {
 		nc.servers[i] = &CollectedServer{
 			ID:  s.ID,
-			URL: s.URL + "/streaming/channelsz?subs=1",
+			URL: s.URL + ChannelszSuffix,
 		}
 	}
 
@@ -294,6 +297,22 @@ func (nc *channelsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- nc.subsMaxInFlight
 }
 
+func getRoleFromChannelszURL(client *http.Client, url string) string {
+	if !strings.HasSuffix(url, ChannelszSuffix) {
+		return ""
+	}
+
+	var newURL = (strings.TrimSuffix(url, ChannelszSuffix) + ServerzSuffix)
+
+	println("Getting metrics from %s", newURL)
+	var serverResp StreamingServerz
+	if err := getMetricURL(client, newURL, &serverResp); err != nil {
+		return "error_getting_role"
+	}
+
+	return serverResp.Role
+}
+
 func (nc *channelsCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, server := range nc.servers {
 		var resp Channelsz
@@ -301,14 +320,15 @@ func (nc *channelsCollector) Collect(ch chan<- prometheus.Metric) {
 			Debugf("ignoring server %s: %v", server.ID, err)
 			continue
 		}
+		var serverRole = getRoleFromChannelszURL(nc.httpClient, server.URL)
 
 		for _, channel := range resp.Channels {
 			ch <- prometheus.MustNewConstMetric(nc.chanBytesTotal, prometheus.GaugeValue,
-				float64(channel.Bytes), server.ID, channel.Name)
+				float64(channel.Bytes), serverRole, server.ID, channel.Name)
 			ch <- prometheus.MustNewConstMetric(nc.chanMsgsTotal, prometheus.GaugeValue,
-				float64(channel.Msgs), server.ID, channel.Name)
+				float64(channel.Msgs), serverRole, server.ID, channel.Name)
 			ch <- prometheus.MustNewConstMetric(nc.chanLastSeq, prometheus.GaugeValue,
-				float64(channel.LastSeq), server.ID, channel.Name)
+				float64(channel.LastSeq), serverRole, server.ID, channel.Name)
 
 			for _, sub := range channel.Subscriptions {
 
@@ -320,7 +340,7 @@ func (nc *channelsCollector) Collect(ch chan<- prometheus.Metric) {
 					subStrings := strings.Split(queueName, ":")
 					durableName, queueName = subStrings[0], subStrings[1]
 				}
-				labelValues := []string{server.ID, channel.Name, sub.ClientID, sub.Inbox,
+				labelValues := []string{server.ID, serverRole, channel.Name, sub.ClientID, sub.Inbox,
 					queueName, strconv.FormatBool(sub.IsDurable), strconv.FormatBool(sub.IsOffline), durableName}
 
 				ch <- prometheus.MustNewConstMetric(nc.subsLastSent, prometheus.GaugeValue,


### PR DESCRIPTION
When reading stats like pending count and max in flight it is helpful to filter by
server role != Follower, because followers will report a max in flight but a pending
count of 0.

Example: to determine queue saturation, I would query the following:

```
sum(nss_chan_subs_pending_count) by (channel, queue, durable_name)
  / sum(nss_chan_subs_max_inflight) by (channel, queue, durable_name)
```

But the sum on the right hand side will be too large - Follower nodes
report the same value as the Leader.

Say I have 4 subcribers, each with a max in flight of 10, and a "true"
pending count of 10 messages (divided however), and a cluster size of
5 nodes.

The real "saturation" value should be 25%, (10 pending / (10 max in flight * 4 subscribers))

However with no way to filter out the follower nodes the saturation is reported
as 5%. The numerator is still 10, but the denominator will be `10 * 4 * 5`, the
true max in flight multiplied by subscribers multiplied by servers reporting the
max in flight.