### PR TITLE
Rename uptime_time to uptime in replicator varz

### DIFF
--- a/collector/replicator.go
+++ b/collector/replicator.go
@@ -70,7 +70,7 @@ type replicatorConnector struct {
 type replicatorVarz struct {
 	StartTime    int                   `json:"start_time"`
 	CurrentTime  int                   `json:"current_time"`
-	Uptime       string                `json:"uptime_time"`
+	Uptime       string                `json:"uptime"`
 	RequestCount int                   `json:"request_count"`
 	Connectors   []replicatorConnector `json:"connectors"`
 	HTTPRequests map[string]int64      `json:"http_requests"`


### PR DESCRIPTION
Fixes empty uptime for `-replicatorVarz`

Before:

```
replicator_server_info{server_id="http://localhost:9090",uptime=""} 1
```

After:

```
replicator_server_info{server_id="http://localhost:9090",uptime="12m9.366599934s"} 1
```