### PR TITLE
Update CI Go

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.15, 1.14.9]
+        go: [1.16, 1.15]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/prometheus-nats-exporter
 
-go 1.15
+go 1.16
 
 require (
 	github.com/gogo/protobuf v1.2.2-0.20190316100346-88dda4156dab // indirect


### PR DESCRIPTION
`make install-tools` is failing in CI because we're using too old of a version of Go. `golangci-lint` requires at least Go 1.15.

This updates Go to 1.15 and 1.16. The [latest Go](https://golang.org/dl/) version is 1.16.5.