### PR TITLE
Add leafz metrics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ prometheus-nats-exporter <flags> url
     	Get connection metrics.
   -gatewayz
     	Get gateway metrics.
+  -leafz
+    	Get leaf metrics.
   -http_pass string
     	Set the password for HTTP scrapes. NATS bcrypt supported.
   -http_user string

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -415,7 +415,9 @@ func NewCollector(system, endpoint, prefix string, servers []*CollectedServer) p
 	if isGatewayzEndpoint(system, endpoint) {
 		return newGatewayzCollector(getSystem(system, prefix), endpoint, servers)
 	}
-
+	if isLeafzEndpoint(system, endpoint) {
+		return newLeafzCollector(getSystem(system, prefix), endpoint, servers)
+	}
 	if isReplicatorEndpoint(system, endpoint) {
 		return newReplicatorCollector(getSystem(system, prefix), servers)
 	}

--- a/collector/leafz.go
+++ b/collector/leafz.go
@@ -1,0 +1,203 @@
+// Copyright 2017-2019 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package collector has various collector utilities and implementations.
+package collector
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// isLeafzEndpoint returns wether an endpoint is a leafz or not.
+func isLeafzEndpoint(system, endpoint string) bool {
+	return system == CoreSystem && endpoint == "leafz"
+}
+
+// leafzCollector is reponsible to gather metrics on leaf nodes.
+type leafzCollector struct {
+	sync.Mutex
+
+	httpClient     *http.Client
+	servers        []*CollectedServer
+	leafNodesTotal *prometheus.Desc
+	leafMetrics    *leafMetrics
+}
+
+// newLeafzCollector creates a new instance of a leafzCollector.
+func newLeafzCollector(system, endpoint string, servers []*CollectedServer) prometheus.Collector {
+	nc := &leafzCollector{httpClient: http.DefaultClient}
+	nc.leafNodesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(system, endpoint, "conn_nodes_total"),
+		"nodes_total",
+		[]string{"server_id"},
+		nil)
+	nc.leafMetrics = newLeafMetrics(system, endpoint)
+	nc.servers = make([]*CollectedServer, len(servers))
+	for i, s := range servers {
+		nc.servers[i] = &CollectedServer{
+			ID:  s.ID,
+			URL: s.URL + "/leafz",
+		}
+	}
+	return nc
+}
+
+// Describe destribes the list of prometheus descriptors available
+// to be scraped.
+func (nc *leafzCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- nc.leafNodesTotal
+	nc.leafMetrics.Describe(ch)
+}
+
+// Collect gathers the server leafz metrics.
+func (nc *leafzCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, server := range nc.servers {
+		var resp Leafz
+		if err := getMetricURL(nc.httpClient, server.URL, &resp); err != nil {
+			Debugf("ignoring server %s: %v", server.ID, err)
+			continue
+		}
+		for _, lf := range resp.Leafs {
+			nc.leafMetrics.Collect(server, lf, ch)
+		}
+		ch <- prometheus.MustNewConstMetric(nc.leafNodesTotal, prometheus.GaugeValue,
+			float64(resp.LeafNodes), server.ID)
+	}
+}
+
+// leafMetrics has all of the prometheus descriptors related to
+// each of the leaf node connections of the server being scraped.
+type leafMetrics struct {
+	info                   *prometheus.Desc
+	connRtt                *prometheus.Desc
+	connInMsgs             *prometheus.Desc
+	connOutMsgs            *prometheus.Desc
+	connInBytes            *prometheus.Desc
+	connOutBytes           *prometheus.Desc
+	connSubscriptionsTotal *prometheus.Desc
+	connSubscriptions      *prometheus.Desc
+}
+
+// newLeafMetrics initializes a new instance of leafMetrics.
+func newLeafMetrics(system, endpoint string) *leafMetrics {
+	leaf := &leafMetrics{
+		info: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "info"),
+			"info",
+			[]string{"server_id", "account", "ip", "port"},
+			nil),
+		connRtt: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "conn_rtt"),
+			"rtt",
+			[]string{"server_id", "account", "ip", "port"},
+			nil),
+		connInMsgs: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "conn_in_msgs"),
+			"in_msgs",
+			[]string{"server_id", "account", "ip", "port"},
+			nil),
+		connOutMsgs: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "conn_out_msgs"),
+			"out_msgs",
+			[]string{"server_id", "account", "ip", "port"},
+			nil),
+		connInBytes: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "conn_in_bytes"),
+			"in_bytes",
+			[]string{"server_id", "account", "ip", "port"},
+			nil),
+		connOutBytes: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "conn_out_bytes"),
+			"out_bytes",
+			[]string{"server_id", "account", "ip", "port"},
+			nil),
+		connSubscriptionsTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "conn_subscriptions_total"),
+			"subscriptions_total",
+			[]string{"server_id", "account", "ip", "port"},
+			nil),
+		connSubscriptions: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "conn_subscriptions"),
+			"subscriptions",
+			[]string{"server_id", "account", "ip", "port", "subscription"},
+			nil),
+	}
+
+	return leaf
+}
+
+// Describe destribes the list of prometheus descriptors available
+// to be scraped.
+func (lf *leafMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- lf.info
+	ch <- lf.connRtt
+	ch <- lf.connInMsgs
+	ch <- lf.connOutMsgs
+	ch <- lf.connInBytes
+	ch <- lf.connOutBytes
+	ch <- lf.connSubscriptionsTotal
+	ch <- lf.connSubscriptions
+}
+
+// Collect collects all the metrics about the a leafnode connection.
+func (lm *leafMetrics) Collect(server *CollectedServer, lf *Leaf, ch chan<- prometheus.Metric) {
+
+	rtt, _ := time.ParseDuration(lf.RTT)
+	ch <- prometheus.MustNewConstMetric(lm.connRtt, prometheus.GaugeValue, rtt.Seconds(),
+		server.ID, lf.Account, lf.IP, fmt.Sprint(lf.Port))
+
+	ch <- prometheus.MustNewConstMetric(lm.connInMsgs, prometheus.GaugeValue, float64(lf.InMsgs),
+		server.ID, lf.Account, lf.IP, fmt.Sprint(lf.Port))
+
+	ch <- prometheus.MustNewConstMetric(lm.connOutMsgs, prometheus.GaugeValue, float64(lf.OutMsgs),
+		server.ID, lf.Account, lf.IP, fmt.Sprint(lf.Port))
+
+	ch <- prometheus.MustNewConstMetric(lm.connInBytes, prometheus.GaugeValue, float64(lf.InBytes),
+		server.ID, lf.Account, lf.IP, fmt.Sprint(lf.Port))
+
+	ch <- prometheus.MustNewConstMetric(lm.connOutBytes, prometheus.GaugeValue, float64(lf.OutBytes),
+		server.ID, lf.Account, lf.IP, fmt.Sprint(lf.Port))
+
+	ch <- prometheus.MustNewConstMetric(lm.connSubscriptionsTotal, prometheus.GaugeValue, float64(lf.Subscriptions),
+		server.ID, lf.Account, lf.IP, fmt.Sprint(lf.Port))
+
+	for _, sub := range lf.SubscriptionsList {
+		ch <- prometheus.MustNewConstMetric(lm.connSubscriptions, prometheus.GaugeValue, float64(0.0),
+			server.ID, lf.Account, lf.IP, fmt.Sprint(lf.Port), sub)
+	}
+}
+
+// Leafz output
+type Leafz struct {
+	LeafNodes int     `json:"leafnodes"`
+	Leafs     []*Leaf `json:"leafs"`
+}
+
+// Leaf output
+type Leaf struct {
+	Account           string   `json:"account"`
+	IP                string   `json:"ip"`
+	Port              int      `json:"port"`
+	RTT               string   `json:"rtt"`
+	InMsgs            int      `json:"in_msgs"`
+	OutMsgs           int      `json:"out_msgs"`
+	InBytes           int      `json:"in_bytes"`
+	OutBytes          int      `json:"out_bytes"`
+	Subscriptions     int      `json:"subscriptions"`
+	SubscriptionsList []string `json:"subscriptions_list"`
+}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -49,6 +49,7 @@ type NATSExporterOptions struct {
 	GetSubz              bool
 	GetRoutez            bool
 	GetGatewayz          bool
+	GetLeafz             bool
 	GetReplicatorVarz    bool
 	GetStreamingChannelz bool
 	GetStreamingServerz  bool
@@ -173,7 +174,7 @@ func (ne *NATSExporter) initializeCollectors() error {
 
 	getJsz := opts.GetJszFilter != ""
 	if !opts.GetConnz && !opts.GetRoutez && !opts.GetSubz && !opts.GetVarz &&
-		!opts.GetGatewayz && !opts.GetStreamingChannelz &&
+		!opts.GetGatewayz && !opts.GetLeafz && !opts.GetStreamingChannelz &&
 		!opts.GetStreamingServerz && !opts.GetReplicatorVarz && !getJsz {
 		return fmt.Errorf("no collectors specfied")
 	}
@@ -191,6 +192,9 @@ func (ne *NATSExporter) initializeCollectors() error {
 	}
 	if opts.GetGatewayz {
 		ne.createCollector(collector.CoreSystem, "gatewayz")
+	}
+	if opts.GetLeafz {
+		ne.createCollector(collector.CoreSystem, "leafz")
 	}
 	if opts.GetRoutez {
 		ne.createCollector(collector.CoreSystem, "routez")

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -142,6 +142,7 @@ func TestExporter(t *testing.T) {
 	opts.GetConnz = true
 	opts.GetSubz = true
 	opts.GetGatewayz = true
+	opts.GetLeafz = true
 	opts.GetRoutez = true
 	opts.GetStreamingChannelz = true
 	opts.GetStreamingServerz = true
@@ -630,6 +631,30 @@ func TestExporterGatewayz(t *testing.T) {
 	defer exp.Stop()
 
 	_, err := checkExporterForResult(exp.http.Addr().String(), "gnatsd_gatewayz_inbound_gateway_conn_in_msgs", false)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestExporterLeafz(t *testing.T) {
+	opts := getStaticExporterTestOptions()
+	opts.ListenAddress = "localhost"
+	opts.ListenPort = 0
+	opts.GetLeafz = true
+
+	serverExit := &sync.WaitGroup{}
+
+	serverExit.Add(1)
+	s := pet.RunLeafzStaticServer(serverExit)
+	defer s.Shutdown(context.TODO())
+
+	exp := NewExporter(opts)
+	if err := exp.Start(); err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer exp.Stop()
+
+	_, err := checkExporterForResult(exp.http.Addr().String(), "gnatsd_leafz_conn_in_msgs", false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func updateOptions(debugAndTrace, useSysLog bool, opts *exporter.NATSExporterOpt
 	}
 
 	metricsSpecified := opts.GetConnz || opts.GetVarz || opts.GetSubz ||
-		opts.GetRoutez || opts.GetGatewayz || opts.GetStreamingChannelz ||
+		opts.GetRoutez || opts.GetGatewayz || opts.GetLeafz || opts.GetStreamingChannelz ||
 		opts.GetStreamingServerz || opts.GetReplicatorVarz || opts.GetJszFilter == ""
 	if !metricsSpecified {
 		// No logger setup yet, so use fmt
@@ -112,6 +112,7 @@ func main() {
 	flag.BoolVar(&opts.GetConnz, "connz", false, "Get connection metrics.")
 	flag.BoolVar(&opts.GetReplicatorVarz, "replicatorVarz", false, "Get replicator general metrics.")
 	flag.BoolVar(&opts.GetGatewayz, "gatewayz", false, "Get gateway metrics.")
+	flag.BoolVar(&opts.GetLeafz, "leafz", false, "Get leaf metrics.")
 	flag.BoolVar(&opts.GetRoutez, "routez", false, "Get route metrics.")
 	flag.BoolVar(&opts.GetSubz, "subz", false, "Get subscription metrics.")
 	flag.BoolVar(&opts.GetStreamingChannelz, "channelz", false, "Get streaming channel metrics.")

--- a/test/data.go
+++ b/test/data.go
@@ -106,3 +106,42 @@ func GatewayzTestResponse() string {
 `
 
 }
+
+func LeafzTestResponse() string {
+	return `{
+	"server_id": "NC2FJCRMPBE5RI5OSRN7TKUCWQONCKNXHKJXCJIDVSAZ6727M7MQFVT3",
+	"now": "2019-08-27T09:07:05.841132-06:00",
+	"leafnodes": 1,
+	"leafs": [
+		{
+			"account": "$G",
+			"ip": "127.0.0.1",
+			"port": 6223,
+			"rtt": "200µs",
+			"in_msgs": 0,
+			"out_msgs": 10000,
+			"in_bytes": 0,
+			"out_bytes": 1280000,
+			"subscriptions": 1,
+			"subscriptions_list": [
+				"foo"
+			]
+		},
+		{
+			"account": "$G",
+			"ip": "127.0.0.2",
+			"port": 6224,
+			"rtt": "400µs",
+			"in_msgs": 20,
+			"out_msgs": 20000,
+			"in_bytes": 30,
+			"out_bytes": 2560000,
+			"subscriptions": 2,
+			"subscriptions_list": [
+				"foo",
+				"bar"
+			]
+		}
+	]
+}`
+}

--- a/test/test.go
+++ b/test/test.go
@@ -70,6 +70,19 @@ func RunGatewayzStaticServer(wg *sync.WaitGroup) *http.Server {
 	return srv
 }
 
+func RunLeafzStaticServer(wg *sync.WaitGroup) *http.Server {
+	srv := &http.Server{Addr: ":" + strconv.Itoa(StaticPort)}
+	http.Handle("/leafz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, LeafzTestResponse())
+	}))
+
+	go func() {
+		defer wg.Done()
+		srv.ListenAndServe()
+	}()
+	return srv
+}
+
 // RunStreamingServerWithPorts runs the STAN server in a go routine allowing
 // the clusterID and ports to be specified..
 func RunStreamingServerWithPorts(clusterID string, port, monitorPort int) *nss.StanServer {


### PR DESCRIPTION
Exporter is not using NATS exposed monitoring endpoint `/leafz` to grab
metrics from the leaf nodes.

We're adding support to expose those metrics.

Co-authored-by: David Peinado <david.peinado@form3.tech>