### PR TITLE
Add freebsd to goreleaser build list

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,8 +14,9 @@ builds:
   main: .
   binary: prometheus-nats-exporter
   goos:
-  - linux
   - darwin
+  - freebsd
+  - linux
   - windows
   goarch:
   - 386


### PR DESCRIPTION
Hi. I am planning to create a FreeBSD port of this exporter for our stan cluster. Building a archive with GOOS `freebsd` would be nice.