### PR TITLE
Bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 export GO111MODULE := on
+drepo ?= natsio
 
 prometheus-nats-exporter.docker:
 	CGO_ENABLED=0 GOOS=linux go build -o $@ -v -a
@@ -10,7 +11,7 @@ dockerx:
 ifneq ($(ver),)
 	# Ensure 'docker buildx ls' shows correct platforms.
 	docker buildx build \
-		--tag natsio/prometheus-nats-exporter:$(ver) --tag natsio/prometheus-nats-exporter:latest \
+		--tag $(drepo)/prometheus-nats-exporter:$(ver) --tag $(drepo)/prometheus-nats-exporter:latest \
 		--platform linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8 \
 		--file docker/linux/Dockerfile \
 		--push .

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build
+FROM golang:1.19 AS build
 COPY . /go/src/prometheus-nats-exporter
 WORKDIR /go/src/prometheus-nats-exporter
 RUN make prometheus-nats-exporter.docker

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/nats-io/prometheus-nats-exporter/exporter"
 )
 
-var version = "0.9.3"
+var version = "0.10.0"
 
 // parseServerIDAndURL parses the url argument the optional id for the server ID.
 func parseServerIDAndURL(urlArg string) (string, string, error) {


### PR DESCRIPTION
- Bump Go version to Go 1.19

Signed-off-by: Waldemar Quevedo <wally@nats.io>