### PR TITLE
Bump version to address CVE-2022-27664

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/nats-io/prometheus-nats-exporter/exporter"
 )
 
-var version = "0.10.0"
+var version = "0.10.1"
 
 // parseServerIDAndURL parses the url argument the optional id for the server ID.
 func parseServerIDAndURL(urlArg string) (string, string, error) {


### PR DESCRIPTION
Since 0.10.0 was published, a new version of Go has been released addressing https://nvd.nist.gov/vuln/detail/CVE-2022-27664.  This will create a new build and docker image to pick up that fix. 
