### PR TITLE
bump golang to 1.19.3 in dockerfile for linux

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 AS build
+FROM golang:1.19.3 AS build
 COPY . /go/src/prometheus-nats-exporter
 WORKDIR /go/src/prometheus-nats-exporter
 RUN make prometheus-nats-exporter.docker

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/nats-io/prometheus-nats-exporter/exporter"
 )
 
-var version = "0.10.0"
+var version = "0.10.1"
 
 // parseServerIDAndURL parses the url argument the optional id for the server ID.
 func parseServerIDAndURL(urlArg string) (string, string, error) {


### PR DESCRIPTION
this PR bumps the golang version in Dockerfile to `v1.19.3`to increase performance and prevent potential security issues. 