### PR TITLE
fix scraping healthz metrics endpoint

### DIFF
--- a/collector/healthz.go
+++ b/collector/healthz.go
@@ -21,8 +21,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	healthzEndpoint = "healthz"
+)
+
 func isHealthzEndpoint(system, endpoint string) bool {
-	return system == CoreSystem && endpoint == "healthz"
+	return system == CoreSystem && endpoint == healthzEndpoint
 }
 
 type healthzCollector struct {
@@ -49,7 +53,7 @@ func newHealthzCollector(system, endpoint string, servers []*CollectedServer) pr
 	for i, s := range servers {
 		nc.servers[i] = &CollectedServer{
 			ID:  s.ID,
-			URL: s.URL + endpoint,
+			URL: s.URL + "/" + healthzEndpoint,
 		}
 	}
 


### PR DESCRIPTION
While for other endpoints (for `varz`, `connz` etc) the URL for the collector was created by server url, a _slash_ and then the endpoint, for the healthz endpoint this wasn't the case. This could be mitigated by adding a trailing / to the given server, but then other collectors would fail. This PR make this behaviour consistent.