### PR TITLE
Improve robustness of generate-certs.sh script

### DIFF
--- a/test/certs/generate-certs.sh
+++ b/test/certs/generate-certs.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+rm -f -- ca.pem client.key client.pem server.key server.pem
+
 # Generate CA
 openssl req -nodes -new -x509 -days 3650 -extensions v3_ca -keyout ca.key -out ca.pem -config openssl.cnf
 

--- a/test/certs/generate-certs.sh
+++ b/test/certs/generate-certs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Generate CA
 openssl req -nodes -new -x509 -days 3650 -extensions v3_ca -keyout ca.key -out ca.pem -config openssl.cnf
 


### PR DESCRIPTION
- Stop if anything goes wrong during execution
- Remove output files before attempting to create them
