### PR TITLE
Add Stream subjects count

### DIFF
--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -45,6 +45,7 @@ type jszCollector struct {
 	streamFirstSeq      *prometheus.Desc
 	streamLastSeq       *prometheus.Desc
 	streamConsumerCount *prometheus.Desc
+	streamSubjectCount  *prometheus.Desc
 
 	// Consumer stats
 	consumerDeliveredConsumerSeq *prometheus.Desc
@@ -168,6 +169,13 @@ func newJszCollector(system, endpoint string, servers []*CollectedServer) promet
 			streamLabels,
 			nil,
 		),
+		// jetstream_stream_subjects
+		streamSubjectCount: prometheus.NewDesc(
+			prometheus.BuildFQName(system, "stream", "subject_count"),
+			"Total number of subjects in a stream",
+			streamLabels,
+			nil,
+		),
 		// jetstream_consumer_delivered_consumer_seq
 		consumerDeliveredConsumerSeq: prometheus.NewDesc(
 			prometheus.BuildFQName(system, "consumer", "delivered_consumer_seq"),
@@ -253,6 +261,7 @@ func (nc *jszCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- nc.streamFirstSeq
 	ch <- nc.streamLastSeq
 	ch <- nc.streamConsumerCount
+	ch <- nc.streamSubjectCount
 
 	// Consumer state
 	ch <- nc.consumerDeliveredConsumerSeq
@@ -354,6 +363,7 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 				ch <- streamMetric(nc.streamFirstSeq, float64(stream.State.FirstSeq))
 				ch <- streamMetric(nc.streamLastSeq, float64(stream.State.LastSeq))
 				ch <- streamMetric(nc.streamConsumerCount, float64(stream.State.Consumers))
+				ch <- streamMetric(nc.streamSubjectCount, float64(stream.State.NumSubjects))
 
 				// Now with the consumers.
 				for _, consumer := range stream.Consumer {


### PR DESCRIPTION
Adds a missing metric for Stream state: number of subjects in the stream.

closes #312

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>