### PR TITLE
Remove unused constants

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -331,11 +331,6 @@ func TestAllEndpoints(t *testing.T) {
 	verifyCollector(CoreSystem, url, "healthz", cases, t)
 }
 
-const (
-	stanClusterName = "test-cluster"
-	stanClientName  = "sample"
-)
-
 func TestLeafzMetricLabels(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/collector/healthz.go
+++ b/collector/healthz.go
@@ -28,7 +28,9 @@ const (
 )
 
 func isHealthzEndpoint(system, endpoint string) bool {
-	return system == CoreSystem && (endpoint == healthzEndpoint || endpoint == healthzJsEnabledOnlyEndpoint || endpoint == healthzJsServerOnlyEndpoint)
+	return system == CoreSystem && (endpoint == healthzEndpoint ||
+		endpoint == healthzJsEnabledOnlyEndpoint ||
+		endpoint == healthzJsServerOnlyEndpoint)
 }
 
 type healthzCollector struct {

--- a/main.go
+++ b/main.go
@@ -121,8 +121,10 @@ func main() {
 	flag.BoolVar(&opts.GetConnzDetailed, "connz_detailed", false,
 		"Get detailed connection metrics for each client. Enables flag `connz` implicitly.")
 	flag.BoolVar(&opts.GetHealthz, "healthz", false, "Get health metrics.")
-	flag.BoolVar(&opts.GetHealthzJsEnabledOnly, "healthz_js_enabled_only", false, "Get health metrics with js-enabled-only=true.")
-	flag.BoolVar(&opts.GetHealthzJsServerOnly, "healthz_js_server_only", false, "Get health metrics with js-server-only=true.")
+	flag.BoolVar(&opts.GetHealthzJsEnabledOnly, "healthz_js_enabled_only", false,
+		"Get health metrics with js-enabled-only=true.")
+	flag.BoolVar(&opts.GetHealthzJsServerOnly, "healthz_js_server_only", false,
+		"Get health metrics with js-server-only=true.")
 	flag.BoolVar(&opts.GetGatewayz, "gatewayz", false, "Get gateway metrics.")
 	flag.BoolVar(&opts.GetAccstatz, "accstatz", false, "Get accstatz metrics.")
 	flag.BoolVar(&opts.GetLeafz, "leafz", false, "Get leaf metrics.")


### PR DESCRIPTION
follow-up to: https://github.com/nats-io/prometheus-nats-exporter/pull/329

Also, fixed other golanci-lint errors:
```
# golangci-lint run ./...
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
ERRO [linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports.
collector/collector_test.go:335:2: const `stanClusterName` is unused (unused)
        stanClusterName = "test-cluster"
        ^
collector/collector_test.go:336:2: const `stanClientName` is unused (unused)
        stanClientName  = "sample"
        ^
main.go:124:1: The line is 127 characters long, which exceeds the maximum of 120 characters. (lll)
        flag.BoolVar(&opts.GetHealthzJsEnabledOnly, "healthz_js_enabled_only", false, "Get health metrics with js-enabled-only=true.")
^
main.go:125:1: The line is 124 characters long, which exceeds the maximum of 120 characters. (lll)
        flag.BoolVar(&opts.GetHealthzJsServerOnly, "healthz_js_server_only", false, "Get health metrics with js-server-only=true.")
^
collector/healthz.go:31:1: The line is 148 characters long, which exceeds the maximum of 120 characters. (lll)
        return system == CoreSystem && (endpoint == healthzEndpoint || endpoint == healthzJsEnabledOnlyEndpoint || endpoint == healthzJsServerOnlyEndpoint)
^

```
