### PR TITLE
Fix linter config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,7 @@ issues:
 linters:
   enable:
     - dupl
-    - exportloopref
+    - copyloopvar
     - gochecknoinits
     - gocritic
     - gocyclo


### PR DESCRIPTION
```
# golangci-lint run ./...
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
ERRO [linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports. 
```
