### PR TITLE
add metric stream_limit_bytes to expose the maximum bytes limit for a stream

### DIFF
--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -379,12 +379,10 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 				ch <- streamMetric(nc.streamSubjectCount, float64(stream.State.NumSubjects))
 
 				if stream.Config != nil {
-					if stream.Config.MaxBytes == -1 {
-						ch <- streamMetric(nc.streamUsage, float64(-1))
-					} else if stream.Config.MaxBytes == 0 {
-						ch <- streamMetric(nc.streamUsage, float64(0))
-					} else {
+					if stream.Config.MaxBytes > 0 {
 						ch <- streamMetric(nc.streamUsage, float64(stream.State.Bytes)/float64(stream.Config.MaxBytes))
+					} else {
+						ch <- streamMetric(nc.streamUsage, float64(stream.Config.MaxBytes))
 					}
 				}
 

--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -349,7 +349,7 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 					maxBytes := stream.Config.MaxBytes
 
 					if maxBytes > 0 {
-						usage = fmt.Sprintf("%.2f%%", (float64(stream.State.Bytes)/float64(maxBytes))*100)
+						usage = fmt.Sprintf("%.2f", (float64(stream.State.Bytes)/float64(maxBytes))*100)
 					} else if maxBytes == 0 {
 						usage = "No Space"
 					} else {

--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -382,7 +382,7 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 					if stream.Config.MaxBytes > 0 {
 						ch <- streamMetric(nc.streamUsage, float64(stream.State.Bytes)/float64(stream.Config.MaxBytes))
 					} else {
-						ch <- streamMetric(nc.streamUsage, float64(stream.Config.MaxBytes))
+						ch <- streamMetric(nc.streamUsage, -1)
 					}
 				}
 

--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -153,7 +153,7 @@ func newJszCollector(system, endpoint string, servers []*CollectedServer) promet
 		// jetstream_stream_usage
 		streamUsage: prometheus.NewDesc(
 			prometheus.BuildFQName(system, "stream", "usage"),
-			"Represents the usage ratio of a JetStream stream as a fraction of its maximum configured storage.",
+			"Represents the usage ratio of a JetStream stream as a fraction of its maximum configured storage",
 			streamLabels,
 			nil,
 		),

--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -16,6 +16,7 @@ package collector
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -73,6 +74,7 @@ func newJszCollector(system, endpoint string, servers []*CollectedServer) promet
 	streamLabels = append(streamLabels, "stream_leader")
 	streamLabels = append(streamLabels, "is_stream_leader")
 	streamLabels = append(streamLabels, "stream_raft_group")
+	streamLabels = append(streamLabels, "limit_bytes")
 
 	var consumerLabels []string
 	consumerLabels = append(consumerLabels, streamLabels...)
@@ -299,7 +301,7 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 			continue
 		}
 		var serverID, serverName, clusterName, jsDomain, clusterLeader string
-		var streamName, streamLeader, streamRaftGroup string
+		var streamName, streamLeader, streamRaftGroup, limitBytes string
 		var consumerName, consumerDesc, consumerLeader string
 		var isMetaLeader, isStreamLeader, isConsumerLeader string
 		var accountName string
@@ -342,6 +344,7 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 			accountID = account.Id
 			for _, stream := range account.Streams {
 				streamName = stream.Name
+				limitBytes = strconv.FormatInt(stream.Config.MaxBytes, 10)
 				if stream.Cluster != nil {
 					streamLeader = stream.Cluster.Leader
 					if streamLeader == serverName {
@@ -359,7 +362,7 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 						// Server Labels
 						serverID, serverName, clusterName, jsDomain, clusterLeader, isMetaLeader,
 						// Stream Labels
-						accountName, accountID, streamName, streamLeader, isStreamLeader, streamRaftGroup)
+						accountName, accountID, streamName, streamLeader, isStreamLeader, streamRaftGroup, limitBytes)
 				}
 				ch <- streamMetric(nc.streamMessages, float64(stream.State.Msgs))
 				ch <- streamMetric(nc.streamBytes, float64(stream.State.Bytes))
@@ -389,7 +392,7 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 							// Server Labels
 							serverID, serverName, clusterName, jsDomain, clusterLeader, isMetaLeader,
 							// Stream Labels
-							accountName, accountID, streamName, streamLeader, isStreamLeader, streamRaftGroup,
+							accountName, accountID, streamName, streamLeader, isStreamLeader, streamRaftGroup, limitBytes,
 							// Consumer Labels
 							consumerName, consumerLeader, isConsumerLeader, consumerDesc,
 						)

--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -153,7 +153,7 @@ func newJszCollector(system, endpoint string, servers []*CollectedServer) promet
 		// jetstream_stream_usage
 		streamUsage: prometheus.NewDesc(
 			prometheus.BuildFQName(system, "stream", "usage"),
-			"Total used bytes from a stream",
+			"Represents the usage ratio of a JetStream stream as a fraction of its maximum configured storage.",
 			streamLabels,
 			nil,
 		),


### PR DESCRIPTION
Fixes : #339 

prefix used :  **nats**

Currently, the JetStream collector provides details on total bytes.

`nats_stream_total_bytes{account="$G", account_id="$G", instance="localhost:7777", is_meta_leader="true", is_stream_leader="true", job="nats-local-server", server_id="http://localhost:8222/", server_name="NCPVYROIZQNGKTRQHGUGK7MYW2A35S25WO6OENIIAMC66ZYTHDIH3RGK", stream_leader="NCPVYROIZQNGKTRQHGUGK7MYW2A35S25WO6OENIIAMC66ZYTHDIH3RGK", stream_name="test-stream"} 305`

PR adds one more metric as `stream_limit_bytes`


**Output after changes:** 

`nats_stream_limit_bytes{account="$G", account_id="$G", instance="localhost:7777", is_meta_leader="true", is_stream_leader="true", job="nats-local-server", server_id="http://localhost:8222", server_name="NCPVYROIZQNGKTRQHGUGK7MYW2A35S25WO6OENIIAMC66ZYTHDIH3RGK", stream_leader="NCPVYROIZQNGKTRQHGUGK7MYW2A35S25WO6OENIIAMC66ZYTHDIH3RGK", stream_name="test-stream"}  -1`


`nats_stream_limit_bytes{account="$G", account_id="$G", instance="localhost:7777", is_meta_leader="true", is_stream_leader="true", job="nats-local-server", server_id="http://localhost:8222", server_name="NCPVYROIZQNGKTRQHGUGK7MYW2A35S25WO6OENIIAMC66ZYTHDIH3RGK", stream_leader="NCPVYROIZQNGKTRQHGUGK7MYW2A35S25WO6OENIIAMC66ZYTHDIH3RGK", stream_name="test-stream4"}  1000`