### PR TITLE
Fix issue with Docker Bake Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
           TAGS: "${{ steps.tags.outputs.tags }}"
           REGISTRY: "natsio"
         with:
+          source: .
           files: docker-bake.hcl
           push: true
           set:


### PR DESCRIPTION
- `docker/bake-action` v6 stopped using current directory as build context