### PR TITLE
feat(grafana): allow to select server and prometheus data sources in NATS Server Grafana dashboard

### DIFF
--- a/walkthrough/grafana-nats-dash-helm.json
+++ b/walkthrough/grafana-nats-dash-helm.json
@@ -151,7 +151,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "nats_varz_cpu",
+          "expr": "nats_varz_cpu{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "nats_varz_cpu",
@@ -243,7 +243,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "nats_varz_mem",
+          "expr": "nats_varz_mem{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "nats_varz_mem",
@@ -346,7 +346,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "nats_varz_in_bytes",
+          "expr": "nats_varz_in_bytes{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "nats_varz_in_bytes",
@@ -436,7 +436,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "nats_varz_in_msgs",
+          "expr": "nats_varz_in_msgs{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "nats_varz_in_msgs",
@@ -526,7 +526,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "nats_varz_out_bytes",
+          "expr": "nats_varz_out_bytes{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "nats_varz_out_bytes",
@@ -616,7 +616,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "nats_varz_out_msgs",
+          "expr": "nats_varz_out_msgs{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "nats_varz_out_msgs",
@@ -722,7 +722,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "nats_varz_connections",
+          "expr": "nats_varz_connections{server_id=~\"$server\"}",
           "intervalFactor": 1,
           "legendFormat": "{{server_id}}",
           "metric": "nats_varz_connections",
@@ -815,7 +815,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "nats_varz_subscriptions",
+          "expr": "nats_varz_subscriptions{server_id=~\"$server\"}",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
@@ -909,7 +909,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "nats_varz_slow_consumers",
+          "expr": "nats_varz_slow_consumers{server_id=~\"$server\"}",
           "intervalFactor": 1,
           "legendFormat": "{{server_id}}",
           "metric": "nats_varz_slow_consumers",
@@ -926,7 +926,28 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {},
+        "definition": "label_values(nats_varz_cpu, server_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Server",
+        "multi": true,
+        "name": "server",
+        "options": [],
+        "query": {
+          "query": "label_values(nats_varz_cpu, server_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query",
+        "datasource": "${DS__NATS-PROMETHEUS}"
+      }
+    ]
   },
   "time": {
     "from": "now-5m",

--- a/walkthrough/grafana-nats-dash.json
+++ b/walkthrough/grafana-nats-dash.json
@@ -151,7 +151,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "gnatsd_varz_cpu",
+          "expr": "gnatsd_varz_cpu{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "gnatsd_varz_cpu",
@@ -243,7 +243,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "gnatsd_varz_mem",
+          "expr": "gnatsd_varz_mem{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "gnatsd_varz_mem",
@@ -346,7 +346,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "gnatsd_varz_in_bytes",
+          "expr": "gnatsd_varz_in_bytes{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "gnatsd_varz_in_bytes",
@@ -436,7 +436,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "gnatsd_varz_in_msgs",
+          "expr": "gnatsd_varz_in_msgs{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "gnatsd_varz_in_msgs",
@@ -526,7 +526,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "gnatsd_varz_out_bytes",
+          "expr": "gnatsd_varz_out_bytes{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "gnatsd_varz_out_bytes",
@@ -616,7 +616,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "gnatsd_varz_out_msgs",
+          "expr": "gnatsd_varz_out_msgs{server_id=~\"$server\"}",
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
           "metric": "gnatsd_varz_out_msgs",
@@ -722,7 +722,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "gnatsd_varz_connections",
+          "expr": "gnatsd_varz_connections{server_id=~\"$server\"}",
           "intervalFactor": 1,
           "legendFormat": "{{server_id}}",
           "metric": "gnatsd_varz_connections",
@@ -815,7 +815,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "gnatsd_varz_subscriptions",
+          "expr": "gnatsd_varz_subscriptions{server_id=~\"$server\"}",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "{{server_id}}",
@@ -909,7 +909,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "gnatsd_varz_slow_consumers",
+          "expr": "gnatsd_varz_slow_consumers{server_id=~\"$server\"}",
           "intervalFactor": 1,
           "legendFormat": "{{server_id}}",
           "metric": "gnatsd_varz_slow_consumers",
@@ -926,7 +926,28 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {},
+        "definition": "label_values(gnatsd_varz_cpu, server_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Server",
+        "multi": true,
+        "name": "server",
+        "options": [],
+        "query": {
+          "query": "label_values(gnatsd_varz_cpu, server_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query",
+        "datasource": "${DS__NATS-PROMETHEUS}"
+      }
+    ]
   },
   "time": {
     "from": "now-5m",


### PR DESCRIPTION
`NATS Jetstream` dashboard works well for me. It allows to both server and prometheus data sources already. However, I am having issue to use the other `NATS Server` dashboard.

This pull request adds the same function to the `NATS Server` dashboard based on `NATS Jetstream` Grafana dashboard.

After adding it, I can confirm `NATS Server` dashboard also allows selecting NATS server. Also Prometheus data shows properly. ☺️

<img width="3828" height="1920" alt="image" src="https://github.com/user-attachments/assets/62d1a39b-7ed5-4c32-aa50-302cb64c1ed9" />
