### PR TITLE
feat(routez): add metrics for route monitoring

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -491,6 +491,9 @@ func NewCollector(system, endpoint, prefix string, servers []*CollectedServer) p
 	if isJszEndpoint(system) {
 		return newJszCollector(getSystem(system, prefix), endpoint, servers, []string{}, []string{})
 	}
+	if isRoutezEndpoint(system, endpoint) {
+		return newRoutezCollector(getSystem(system, prefix), endpoint, servers)
+	}
 	return newNatsCollector(getSystem(system, prefix), endpoint, servers)
 }
 

--- a/collector/routez.go
+++ b/collector/routez.go
@@ -1,0 +1,295 @@
+// Copyright 2017-2019 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package collector has various collector utilities and implementations.
+package collector
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var uptimeRegex = regexp.MustCompile(`(?:(\d+)y)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?`)
+
+// parseNATSUptime parses NATS uptime format like "7d13h49m13s" or "1y2d3h4m5s"
+// into a time.Duration. Returns error if the format is invalid.
+func parseNATSUptime(uptime string) (time.Duration, error) {
+	if uptime == "" {
+		return 0, fmt.Errorf("empty uptime string")
+	}
+
+	matches := uptimeRegex.FindStringSubmatch(uptime)
+	if matches == nil || matches[0] != uptime {
+		return 0, fmt.Errorf("invalid uptime format: %s", uptime)
+	}
+
+	var total time.Duration
+
+	// Parse years (matches[1])
+	if matches[1] != "" {
+		years, _ := strconv.ParseInt(matches[1], 10, 64)
+		total += time.Duration(years) * 365 * 24 * time.Hour
+	}
+
+	// Parse days (matches[2])
+	if matches[2] != "" {
+		days, _ := strconv.ParseInt(matches[2], 10, 64)
+		total += time.Duration(days) * 24 * time.Hour
+	}
+
+	// Parse hours (matches[3])
+	if matches[3] != "" {
+		hours, _ := strconv.ParseInt(matches[3], 10, 64)
+		total += time.Duration(hours) * time.Hour
+	}
+
+	// Parse minutes (matches[4])
+	if matches[4] != "" {
+		minutes, _ := strconv.ParseInt(matches[4], 10, 64)
+		total += time.Duration(minutes) * time.Minute
+	}
+
+	// Parse seconds (matches[5])
+	if matches[5] != "" {
+		seconds, _ := strconv.ParseInt(matches[5], 10, 64)
+		total += time.Duration(seconds) * time.Second
+	}
+
+	if total == 0 {
+		return 0, fmt.Errorf("invalid uptime format: %s", uptime)
+	}
+
+	return total, nil
+}
+
+func isRoutezEndpoint(system, endpoint string) bool {
+	return system == CoreSystem && endpoint == "routez"
+}
+
+type routezCollector struct {
+	sync.Mutex
+
+	httpClient   *http.Client
+	servers      []*CollectedServer
+	serverID     *prometheus.Desc
+	serverName   *prometheus.Desc
+	numRoutes    *prometheus.Desc
+	routeMetrics *routeMetrics
+}
+
+func newRoutezCollector(system, endpoint string, servers []*CollectedServer) prometheus.Collector {
+	rc := &routezCollector{
+		httpClient:   http.DefaultClient,
+		routeMetrics: newRouteMetrics(system, endpoint),
+	}
+	rc.serverID = prometheus.NewDesc(
+		prometheus.BuildFQName(system, endpoint, "server_id"),
+		"server_id",
+		[]string{"server_id", "value"},
+		nil)
+	rc.serverName = prometheus.NewDesc(
+		prometheus.BuildFQName(system, endpoint, "server_name"),
+		"server_name",
+		[]string{"server_id", "value"},
+		nil)
+	rc.numRoutes = prometheus.NewDesc(
+		prometheus.BuildFQName(system, endpoint, "num_routes"),
+		"num_routes",
+		[]string{"server_id"},
+		nil)
+	rc.servers = make([]*CollectedServer, len(servers))
+	for i, s := range servers {
+		rc.servers[i] = &CollectedServer{
+			ID:  s.ID,
+			URL: s.URL + "/routez",
+		}
+	}
+	return rc
+}
+
+func (rc *routezCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- rc.serverID
+	ch <- rc.serverName
+	ch <- rc.numRoutes
+	rc.routeMetrics.Describe(ch)
+}
+
+func (rc *routezCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, server := range rc.servers {
+		var resp Routez
+		if err := getMetricURL(rc.httpClient, server.URL, &resp); err != nil {
+			Debugf("ignoring server %s: %v", server.ID, err)
+			continue
+		}
+
+		ch <- prometheus.MustNewConstMetric(rc.serverID, prometheus.GaugeValue,
+			1, server.ID, resp.ServerID)
+		ch <- prometheus.MustNewConstMetric(rc.serverName, prometheus.GaugeValue,
+			1, server.ID, resp.ServerName)
+		ch <- prometheus.MustNewConstMetric(rc.numRoutes, prometheus.GaugeValue,
+			float64(resp.NumRoutes), server.ID)
+
+		for _, route := range resp.Routes {
+			rc.routeMetrics.Collect(server, &route, ch)
+		}
+	}
+}
+
+type routeMetrics struct {
+	info          *prometheus.Desc
+	rtt           *prometheus.Desc
+	subscriptions *prometheus.Desc
+	uptime        *prometheus.Desc
+	inMsgs        *prometheus.Desc
+	outMsgs       *prometheus.Desc
+	inBytes       *prometheus.Desc
+	outBytes      *prometheus.Desc
+}
+
+func newRouteMetrics(system, endpoint string) *routeMetrics {
+	// Base labels for all metrics (route identifier)
+	baseLabels := []string{"server_id", "rid"}
+	// Extended labels for info metric
+	infoLabels := []string{"server_id", "rid", "remote_id", "remote_name", "account", "ip", "compression"}
+
+	return &routeMetrics{
+		info: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "route_info"),
+			"route_info",
+			infoLabels,
+			nil),
+		rtt: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "route_rtt_seconds"),
+			"rtt_seconds",
+			baseLabels,
+			nil),
+		subscriptions: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "route_subscriptions"),
+			"subscriptions",
+			baseLabels,
+			nil),
+		uptime: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "route_uptime_seconds"),
+			"uptime_seconds",
+			baseLabels,
+			nil),
+		inMsgs: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "route_in_msgs"),
+			"in_msgs",
+			baseLabels,
+			nil),
+		outMsgs: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "route_out_msgs"),
+			"out_msgs",
+			baseLabels,
+			nil),
+		inBytes: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "route_in_bytes"),
+			"in_bytes",
+			baseLabels,
+			nil),
+		outBytes: prometheus.NewDesc(
+			prometheus.BuildFQName(system, endpoint, "route_out_bytes"),
+			"out_bytes",
+			baseLabels,
+			nil),
+	}
+}
+
+func (rm *routeMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- rm.info
+	ch <- rm.rtt
+	ch <- rm.subscriptions
+	ch <- rm.uptime
+	ch <- rm.inMsgs
+	ch <- rm.outMsgs
+	ch <- rm.inBytes
+	ch <- rm.outBytes
+}
+
+func (rm *routeMetrics) Collect(server *CollectedServer, route *RouteInfo, ch chan<- prometheus.Metric) {
+	// Base labels for route identification
+	baseLabels := []string{server.ID, fmt.Sprint(route.Rid)}
+	// Extended labels for info metric
+	infoLabels := []string{server.ID, fmt.Sprint(route.Rid), route.RemoteID, route.RemoteName, route.Account, route.IP, route.Compression}
+
+	ch <- prometheus.MustNewConstMetric(rm.info, prometheus.GaugeValue, float64(1.0),
+		infoLabels...)
+
+	// Only export RTT if available
+	if route.RTT != "" {
+		rtt, err := time.ParseDuration(route.RTT)
+		if err == nil {
+			ch <- prometheus.MustNewConstMetric(rm.rtt, prometheus.GaugeValue, rtt.Seconds(),
+				baseLabels...)
+		}
+	}
+
+	ch <- prometheus.MustNewConstMetric(rm.subscriptions, prometheus.GaugeValue, float64(route.Subscriptions),
+		baseLabels...)
+
+	// Only export uptime if available
+	if route.Uptime != "" {
+		// Try standard Go duration format first
+		uptime, err := time.ParseDuration(route.Uptime)
+		if err != nil {
+			// Try NATS-specific format (e.g., "7d13h49m13s")
+			uptime, err = parseNATSUptime(route.Uptime)
+		}
+		if err == nil {
+			ch <- prometheus.MustNewConstMetric(rm.uptime, prometheus.GaugeValue, uptime.Seconds(),
+				baseLabels...)
+		}
+	}
+
+	ch <- prometheus.MustNewConstMetric(rm.inMsgs, prometheus.GaugeValue, float64(route.InMsgs),
+		baseLabels...)
+
+	ch <- prometheus.MustNewConstMetric(rm.outMsgs, prometheus.GaugeValue, float64(route.OutMsgs),
+		baseLabels...)
+
+	ch <- prometheus.MustNewConstMetric(rm.inBytes, prometheus.GaugeValue, float64(route.InBytes),
+		baseLabels...)
+
+	ch <- prometheus.MustNewConstMetric(rm.outBytes, prometheus.GaugeValue, float64(route.OutBytes),
+		baseLabels...)
+}
+
+type Routez struct {
+	ServerID   string      `json:"server_id"`
+	ServerName string      `json:"server_name"`
+	NumRoutes  int         `json:"num_routes"`
+	Routes     []RouteInfo `json:"routes"`
+}
+
+type RouteInfo struct {
+	Rid           uint64 `json:"rid"`
+	RemoteID      string `json:"remote_id"`
+	RemoteName    string `json:"remote_name"`
+	Account       string `json:"account,omitempty"`
+	IP            string `json:"ip,omitempty"`
+	Compression   string `json:"compression,omitempty"`
+	RTT           string `json:"rtt,omitempty"`
+	Uptime        string `json:"uptime,omitempty"`
+	InMsgs        int64  `json:"in_msgs"`
+	OutMsgs       int64  `json:"out_msgs"`
+	InBytes       int64  `json:"in_bytes"`
+	OutBytes      int64  `json:"out_bytes"`
+	Subscriptions uint32 `json:"subscriptions"`
+}

--- a/collector/routez_test.go
+++ b/collector/routez_test.go
@@ -1,0 +1,103 @@
+// Copyright 2017-2019 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNATSUptime(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+		wantErr  bool
+	}{
+		{
+			name:     "seconds only",
+			input:    "30s",
+			expected: 30 * time.Second,
+			wantErr:  false,
+		},
+		{
+			name:     "minutes and seconds",
+			input:    "45m20s",
+			expected: 45*time.Minute + 20*time.Second,
+			wantErr:  false,
+		},
+		{
+			name:     "hours, minutes and seconds",
+			input:    "3h15m30s",
+			expected: 3*time.Hour + 15*time.Minute + 30*time.Second,
+			wantErr:  false,
+		},
+		{
+			name:     "days, hours, minutes and seconds",
+			input:    "7d13h49m13s",
+			expected: 7*24*time.Hour + 13*time.Hour + 49*time.Minute + 13*time.Second,
+			wantErr:  false,
+		},
+		{
+			name:     "years, days, hours, minutes and seconds",
+			input:    "1y2d3h4m5s",
+			expected: 365*24*time.Hour + 2*24*time.Hour + 3*time.Hour + 4*time.Minute + 5*time.Second,
+			wantErr:  false,
+		},
+		{
+			name:     "only days",
+			input:    "5d",
+			expected: 5 * 24 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "only hours",
+			input:    "12h",
+			expected: 12 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid format",
+			input:    "invalid",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "no units",
+			input:    "123",
+			expected: 0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseNATSUptime(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err, "expected error for input: %s", tt.input)
+			} else {
+				assert.NoError(t, err, "unexpected error for input: %s", tt.input)
+				assert.Equal(t, tt.expected, result, "duration mismatch for input: %s", tt.input)
+			}
+		})
+	}
+}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	pet "github.com/nats-io/prometheus-nats-exporter/test"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -722,4 +723,57 @@ func TestExporterLeafz(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
+}
+
+func TestExporterRoutez(t *testing.T) {
+	opts := getStaticExporterTestOptions()
+	opts.ListenAddress = "localhost"
+	opts.ListenPort = 0
+	opts.GetRoutez = true
+
+	serverExit := &sync.WaitGroup{}
+
+	serverExit.Add(1)
+	s := pet.RunRoutezStaticServer(serverExit)
+	defer s.Shutdown(context.TODO())
+
+	exp := NewExporter(opts)
+	if err := exp.Start(); err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer exp.Stop()
+
+	result, err := checkExporterForResult(exp.addr, "gnatsd_routez_route")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Check for top-level metrics
+	assert.Contains(t, result, "gnatsd_routez_server_id", "should export server_id metric")
+	assert.Contains(t, result, "gnatsd_routez_server_name", "should export server_name metric")
+	assert.Contains(t, result, `gnatsd_routez_num_routes{server_id="`, "should export num_routes metric")
+
+	// Check for route-specific metrics
+	assert.Contains(t, result, "gnatsd_routez_route_info", "should export route_info metric")
+	assert.Contains(t, result, "gnatsd_routez_route_subscriptions", "should export subscriptions metric")
+	assert.Contains(t, result, "gnatsd_routez_route_in_msgs", "should export in_msgs metric")
+	assert.Contains(t, result, "gnatsd_routez_route_out_msgs", "should export out_msgs metric")
+	assert.Contains(t, result, "gnatsd_routez_route_in_bytes", "should export in_bytes metric")
+	assert.Contains(t, result, "gnatsd_routez_route_out_bytes", "should export out_bytes metric")
+
+	// Check for optional metrics - both should be present in test data now
+	assert.Contains(t, result, "gnatsd_routez_route_rtt_seconds", "should export rtt_seconds metric")
+	assert.Contains(t, result, "gnatsd_routez_route_uptime_seconds", "should export uptime_seconds metric")
+
+	// Check for specific label values from test data
+	assert.Contains(t, result, `remote_name="server-b"`, "should have server-b route")
+	assert.Contains(t, result, `remote_name="server-c"`, "should have server-c route")
+	assert.Contains(t, result, `account="SYS"`, "should have SYS account label")
+	assert.Contains(t, result, `compression="off"`, "should have compression label")
+	assert.Contains(t, result, `rid="10"`, "should have rid 10")
+	assert.Contains(t, result, `rid="16"`, "should have rid 16")
+
+	// Check for actual metric values from test data
+	assert.Contains(t, result, `gnatsd_routez_route_in_msgs{rid="16",server_id="`, "should export in_msgs for rid 16")
+	assert.Contains(t, result, `gnatsd_routez_route_subscriptions{rid="10",server_id="`, "should export subscriptions for rid 10")
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/nats-io/nats.go v1.48.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.47.0
 )
 
@@ -14,6 +15,7 @@ require (
 	github.com/antithesishq/antithesis-sdk-go v0.5.0-default-no-op // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -22,10 +24,12 @@ require (
 	github.com/nats-io/jwt/v2 v2.8.0 // indirect
 	github.com/nats-io/nkeys v0.4.12 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/test/data.go
+++ b/test/data.go
@@ -120,6 +120,61 @@ func GatewayzTestResponse() string {
 
 }
 
+func RoutezTestResponse() string {
+	return `
+{
+  "server_id": "NDFDEPOQYFZSSB6QDWGZSJII6SCG7XG3M2ZPKVHAU4QCFANKG3EKQ7KD",
+  "server_name": "server-a",
+  "now": "2026-02-03T21:25:39.390699121Z",
+  "num_routes": 2,
+  "routes": [
+    {
+      "rid": 10,
+      "remote_id": "NDJUPHLDJX2J5NM7L6XRXQLVIGG33W35FOHGIVZKNO2XZZDJBMO54CAY",
+      "remote_name": "server-b",
+      "did_solicit": true,
+      "is_configured": true,
+      "ip": "10.89.201.117",
+      "port": 6222,
+      "start": "2026-01-27T07:36:25.596386302Z",
+      "last_activity": "2026-02-03T21:23:20.120573554Z",
+      "rtt": "815µs",
+      "uptime": "7d13h49m13s",
+      "idle": "2m19s",
+      "pending_size": 0,
+      "in_msgs": 2,
+      "out_msgs": 2,
+      "in_bytes": 196,
+      "out_bytes": 31,
+      "subscriptions": 2,
+      "compression": "off"
+    },
+    {
+      "rid": 16,
+      "remote_id": "NDJUPHLDJX2J5NM7L6XRXQLVIGG33W35FOHGIVZKNO2XZZDJBMO54CAY",
+      "remote_name": "server-c",
+      "did_solicit": true,
+      "is_configured": true,
+      "ip": "10.89.201.82",
+      "port": 6222,
+      "start": "2026-01-27T07:36:13.038038228Z",
+      "last_activity": "2026-02-03T21:25:39.346602191Z",
+      "rtt": "924µs",
+      "uptime": "7d13h49m26s",
+      "idle": "0s",
+      "pending_size": 0,
+      "in_msgs": 5954512,
+      "out_msgs": 2184642,
+      "in_bytes": 5963399347,
+      "out_bytes": 2169821095,
+      "subscriptions": 80,
+      "account": "SYS",
+      "compression": "off"
+    }
+  ]
+}`
+}
+
 // AccstatzTestResponse is static data for tests
 func AccstatzTestResponse() string {
 	return `{

--- a/test/test.go
+++ b/test/test.go
@@ -94,6 +94,20 @@ func RunLeafzStaticServer(wg *sync.WaitGroup) *http.Server {
 	return srv
 }
 
+// RunRoutezStaticServer runs a leafz static server.
+func RunRoutezStaticServer(wg *sync.WaitGroup) *http.Server {
+	srv := &http.Server{Addr: ":" + strconv.Itoa(StaticPort)}
+	http.Handle("/routez", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, RoutezTestResponse())
+	}))
+
+	go func() {
+		defer wg.Done()
+		srv.ListenAndServe()
+	}()
+	return srv
+}
+
 // RunServerWithPortsAndName runs the NATS server with a monitor port and a name in a go routine
 func RunServerWithPortsAndName(cport, mport int, serverName string) *server.Server {
 	var enableLogging bool


### PR DESCRIPTION
Adds metrics from /routez endpoint with:

- `gnatsd_routez_route_info` - info metric with remote_id, remote_name, account, ip, compression labels
- `gnatsd_routez_route_rtt_seconds` - round-trip time
- `gnatsd_routez_route_subscriptions` - number of subscriptions
- `gnatsd_routez_route_uptime_seconds` - route uptime
- `gnatsd_routez_route_in_msgs` - incoming messages
- `gnatsd_routez_route_out_msgs` - outgoing messages
- `gnatsd_routez_route_in_bytes` - incoming bytes
- `gnatsd_routez_route_out_bytes` - outgoing bytes


```
# HELP gnatsd_routez_route_in_bytes in_bytes
# TYPE gnatsd_routez_route_in_bytes gauge
gnatsd_routez_route_in_bytes{rid="10",server_id="http://custom-nats-server:8222"} 0
gnatsd_routez_route_in_bytes{rid="11",server_id="http://custom-nats-server:8222"} 6.716322303e+09
gnatsd_routez_route_in_bytes{rid="12",server_id="http://custom-nats-server:8222"} 6.267727822e+09
gnatsd_routez_route_in_bytes{rid="14",server_id="http://custom-nats-server:8222"} 0
# HELP gnatsd_routez_route_in_msgs in_msgs
# TYPE gnatsd_routez_route_in_msgs gauge
gnatsd_routez_route_in_msgs{rid="10",server_id="http://custom-nats-server:8222"} 0
gnatsd_routez_route_in_msgs{rid="11",server_id="http://custom-nats-server:8222"} 6.705807e+06
gnatsd_routez_route_in_msgs{rid="12",server_id="http://custom-nats-server:8222"} 7.513855e+06
gnatsd_routez_route_in_msgs{rid="14",server_id="http://custom-nats-server:8222"} 0
# HELP gnatsd_routez_route_info route_info
# TYPE gnatsd_routez_route_info gauge
gnatsd_routez_route_info{account="",compression="off",ip="10.89.201.79",remote_id="NDJUPHLDJX2J5NM7L6XRXQLVIGG33W35FOHGIVZKNO2XZZDJBMO54CAY",remote_name="a-3",rid="10",server_id="http://custom-nats-server:8222"} 1
gnatsd_routez_route_info{account="",compression="off",ip="10.89.201.82",remote_id="NASELQM7ZFCT4XJRS4KDVKXB3CY7UDSGF2FX3J6V6VKDKDNPSGUFPNNG",remote_name="a-4",rid="14",server_id="http://custom-nats-server:8222"} 1
gnatsd_routez_route_info{account="SYS",compression="off",ip="10.89.201.79",remote_id="NDJUPHLDJX2J5NM7L6XRXQLVIGG33W35FOHGIVZKNO2XZZDJBMO54CAY",remote_name="a-3",rid="12",server_id="http://custom-nats-server:8222"} 1
gnatsd_routez_route_info{account="SYS",compression="off",ip="10.89.201.82",remote_id="NASELQM7ZFCT4XJRS4KDVKXB3CY7UDSGF2FX3J6V6VKDKDNPSGUFPNNG",remote_name="a-4",rid="11",server_id="http://custom-nats-server:8222"} 1
# HELP gnatsd_routez_route_out_bytes out_bytes
# TYPE gnatsd_routez_route_out_bytes gauge
gnatsd_routez_route_out_bytes{rid="10",server_id="http://custom-nats-server:8222"} 0
gnatsd_routez_route_out_bytes{rid="11",server_id="http://custom-nats-server:8222"} 2.443788859e+09
gnatsd_routez_route_out_bytes{rid="12",server_id="http://custom-nats-server:8222"} 2.4807804e+09
gnatsd_routez_route_out_bytes{rid="14",server_id="http://custom-nats-server:8222"} 0
# HELP gnatsd_routez_route_out_msgs out_msgs
# TYPE gnatsd_routez_route_out_msgs gauge
gnatsd_routez_route_out_msgs{rid="10",server_id="http://custom-nats-server:8222"} 0
gnatsd_routez_route_out_msgs{rid="11",server_id="http://custom-nats-server:8222"} 2.460142e+06
gnatsd_routez_route_out_msgs{rid="12",server_id="http://custom-nats-server:8222"} 3.930031e+06
gnatsd_routez_route_out_msgs{rid="14",server_id="http://custom-nats-server:8222"} 0
# HELP gnatsd_routez_route_rtt_seconds rtt_seconds
# TYPE gnatsd_routez_route_rtt_seconds gauge
gnatsd_routez_route_rtt_seconds{rid="10",server_id="http://custom-nats-server:8222"} 0.000734
gnatsd_routez_route_rtt_seconds{rid="11",server_id="http://custom-nats-server:8222"} 0.001647576
gnatsd_routez_route_rtt_seconds{rid="12",server_id="http://custom-nats-server:8222"} 0.000734
gnatsd_routez_route_rtt_seconds{rid="14",server_id="http://custom-nats-server:8222"} 0.001332471
# HELP gnatsd_routez_route_subscriptions subscriptions
# TYPE gnatsd_routez_route_subscriptions gauge
gnatsd_routez_route_subscriptions{rid="10",server_id="http://custom-nats-server:8222"} 0
gnatsd_routez_route_subscriptions{rid="11",server_id="http://custom-nats-server:8222"} 80
gnatsd_routez_route_subscriptions{rid="12",server_id="http://custom-nats-server:8222"} 81
gnatsd_routez_route_subscriptions{rid="14",server_id="http://custom-nats-server:8222"} 0
```