### PR TITLE
Bump Go from 1.25.5 to 1.26.0 to fix security issues

### DIFF
--- a/cicd/Dockerfile_goreleaser
+++ b/cicd/Dockerfile_goreleaser
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.13
-FROM --platform=$BUILDPLATFORM golang:1.25.6-trixie AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.0-trixie AS build
 
 ARG GITHUB_RUN_ID
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/prometheus-nats-exporter
 
-go 1.25.5
+go 1.26.0
 
 require (
 	github.com/nats-io/nats-server/v2 v2.12.4


### PR DESCRIPTION
Fix security issue in standard Go library:

```
trivy image --severity HIGH,CRITICAL natsio/prometheus-nats-exporter:0.19.1 --quiet

Report Summary

┌────────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                         Target                         │   Type   │ Vulnerabilities │ Secrets │
├────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ natsio/prometheus-nats-exporter:0.19.1 (alpine 3.23.3) │  alpine  │        0        │    -    │
├────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/prometheus-nats-exporter                 │ gobinary │        1        │    -    │
└────────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


usr/local/bin/prometheus-nats-exporter (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬─────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                          Title                          │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼─────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-68121 │ CRITICAL │ fixed  │ v1.25.6           │ 1.24.13, 1.25.7, 1.26.0-rc.3 │ crypto/tls: Unexpected session resumption in crypto/tls │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-68121              │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴─────────────────────────────────────────────────────────┘
```