### PR TITLE
Add last_delivery and last_ack metrics

### DIFF
--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -283,14 +283,14 @@ func newJszCollector(
 		// jetstream_consumer_last_delivery_seconds
 		consumerLastDelivery: prometheus.NewDesc(
 			prometheus.BuildFQName(system, "consumer", "last_delivery_seconds"),
-			"Last delivered time in seconds",
+			"Seconds since last message delivery to consumer",
 			consumerLabels,
 			nil,
 		),
 		// jetstream_consumer_last_ack_seconds
 		consumerLastAck: prometheus.NewDesc(
 			prometheus.BuildFQName(system, "consumer", "last_ack_seconds"),
-			"Last ack time in seconds",
+			"Seconds since last ack from consumer",
 			consumerLabels,
 			nil,
 		),

--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -623,11 +623,11 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 						return prometheus.MustNewConstMetric(key, prometheus.GaugeValue, value, consumerLabelValues...)
 					}
 					if consumer.Delivered.Last != nil {
-						consumerLastDelivery := float64(consumer.TimeStamp.Sub(*consumer.Delivered.Last).Seconds())
+						consumerLastDelivery := consumer.TimeStamp.Sub(*consumer.Delivered.Last).Seconds()
 						ch <- consumerMetric(nc.consumerLastDelivery, consumerLastDelivery)
 					}
 					if consumer.AckFloor.Last != nil {
-						consumerLastAck := float64(consumer.TimeStamp.Sub(*consumer.AckFloor.Last).Seconds())
+						consumerLastAck := consumer.TimeStamp.Sub(*consumer.AckFloor.Last).Seconds()
 						ch <- consumerMetric(nc.consumerLastAck, consumerLastAck)
 					}
 					ch <- consumerMetric(nc.consumerDeliveredConsumerSeq, float64(consumer.Delivered.Consumer))

--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -622,18 +622,16 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 					consumerMetric := func(key *prometheus.Desc, value float64) prometheus.Metric {
 						return prometheus.MustNewConstMetric(key, prometheus.GaugeValue, value, consumerLabelValues...)
 					}
-					var consumerLastDelivery float64
 					if consumer.Delivered.Last != nil {
-						consumerLastDelivery = float64(consumer.TimeStamp.Sub(*consumer.Delivered.Last).Seconds())
+						consumerLastDelivery := float64(consumer.TimeStamp.Sub(*consumer.Delivered.Last).Seconds())
+						ch <- consumerMetric(nc.consumerLastDelivery, consumerLastDelivery)
 					}
-					var consumerLastAck float64
 					if consumer.AckFloor.Last != nil {
-						consumerLastAck = float64(consumer.TimeStamp.Sub(*consumer.AckFloor.Last).Seconds())
+						consumerLastAck := float64(consumer.TimeStamp.Sub(*consumer.AckFloor.Last).Seconds())
+						ch <- consumerMetric(nc.consumerLastAck, consumerLastAck)
 					}
 					ch <- consumerMetric(nc.consumerDeliveredConsumerSeq, float64(consumer.Delivered.Consumer))
 					ch <- consumerMetric(nc.consumerDeliveredStreamSeq, float64(consumer.Delivered.Stream))
-					ch <- consumerMetric(nc.consumerLastDelivery, consumerLastDelivery)
-					ch <- consumerMetric(nc.consumerLastAck, consumerLastAck)
 					ch <- consumerMetric(nc.consumerNumAckPending, float64(consumer.NumAckPending))
 					ch <- consumerMetric(nc.consumerNumRedelivered, float64(consumer.NumRedelivered))
 					ch <- consumerMetric(nc.consumerNumWaiting, float64(consumer.NumWaiting))

--- a/collector/jsz.go
+++ b/collector/jsz.go
@@ -58,6 +58,8 @@ type jszCollector struct {
 	// Consumer stats
 	consumerDeliveredConsumerSeq *prometheus.Desc
 	consumerDeliveredStreamSeq   *prometheus.Desc
+	consumerLastDelivery         *prometheus.Desc
+	consumerLastAck              *prometheus.Desc
 	consumerNumAckPending        *prometheus.Desc
 	consumerNumRedelivered       *prometheus.Desc
 	consumerNumWaiting           *prometheus.Desc
@@ -278,6 +280,20 @@ func newJszCollector(
 			consumerLabels,
 			nil,
 		),
+		// jetstream_consumer_last_delivery_seconds
+		consumerLastDelivery: prometheus.NewDesc(
+			prometheus.BuildFQName(system, "consumer", "last_delivery_seconds"),
+			"Last delivered time in seconds",
+			consumerLabels,
+			nil,
+		),
+		// jetstream_consumer_last_ack_seconds
+		consumerLastAck: prometheus.NewDesc(
+			prometheus.BuildFQName(system, "consumer", "last_ack_seconds"),
+			"Last ack time in seconds",
+			consumerLabels,
+			nil,
+		),
 		// jetstream_consumer_num_ack_pending
 		consumerNumAckPending: prometheus.NewDesc(
 			prometheus.BuildFQName(system, "consumer", "num_ack_pending"),
@@ -386,6 +402,8 @@ func (nc *jszCollector) Describe(ch chan<- *prometheus.Desc) {
 	// Consumer state
 	ch <- nc.consumerDeliveredConsumerSeq
 	ch <- nc.consumerDeliveredStreamSeq
+	ch <- nc.consumerLastDelivery
+	ch <- nc.consumerLastAck
 	ch <- nc.consumerNumAckPending
 	ch <- nc.consumerNumRedelivered
 	ch <- nc.consumerNumWaiting
@@ -604,8 +622,18 @@ func (nc *jszCollector) Collect(ch chan<- prometheus.Metric) {
 					consumerMetric := func(key *prometheus.Desc, value float64) prometheus.Metric {
 						return prometheus.MustNewConstMetric(key, prometheus.GaugeValue, value, consumerLabelValues...)
 					}
+					var consumerLastDelivery float64
+					if consumer.Delivered.Last != nil {
+						consumerLastDelivery = float64(consumer.TimeStamp.Sub(*consumer.Delivered.Last).Seconds())
+					}
+					var consumerLastAck float64
+					if consumer.AckFloor.Last != nil {
+						consumerLastAck = float64(consumer.TimeStamp.Sub(*consumer.AckFloor.Last).Seconds())
+					}
 					ch <- consumerMetric(nc.consumerDeliveredConsumerSeq, float64(consumer.Delivered.Consumer))
 					ch <- consumerMetric(nc.consumerDeliveredStreamSeq, float64(consumer.Delivered.Stream))
+					ch <- consumerMetric(nc.consumerLastDelivery, consumerLastDelivery)
+					ch <- consumerMetric(nc.consumerLastAck, consumerLastAck)
 					ch <- consumerMetric(nc.consumerNumAckPending, float64(consumer.NumAckPending))
 					ch <- consumerMetric(nc.consumerNumRedelivered, float64(consumer.NumRedelivered))
 					ch <- consumerMetric(nc.consumerNumWaiting, float64(consumer.NumWaiting))


### PR DESCRIPTION
Hello,

Nats cli has one useful feature - in `nats con info <STREAM> <CONSUMER>` output it prints Last delivery and Last Ack information, that can be useful in troubleshooting:

```
  Last Delivered Message: Consumer sequence: 47,917,905 Stream sequence: 96,703,953 Last delivery: 2.25s ago
    Acknowledgment Floor: Consumer sequence: 47,917,895 Stream sequence: 96,703,918 Last Ack: 410ms ago
```

This PR adds 2 new metrics with this information:

* jetstream_consumer_last_delivery_seconds
* jetstream_consumer_last_ack_seconds

The code is based on [nats cli](https://github.com/nats-io/natscli/blob/d2eb4f7870d8c27bd54899efde650354d0a054c5/cli/consumer_command.go#L1257)